### PR TITLE
feat(api): add helmet for security headers (#25)

### DIFF
--- a/apps/hearthly-api/package.json
+++ b/apps/hearthly-api/package.json
@@ -85,6 +85,7 @@
     "@nestjs/platform-express": "^11.0.0",
     "@nestjs/terminus": "^11.1.1",
     "drizzle-orm": "^0.45.1",
+    "helmet": "^8.1.0",
     "nestjs-cls": "^6.2.0",
     "postgres": "^3.4.8",
     "reflect-metadata": "^0.1.13",

--- a/apps/hearthly-api/src/main.ts
+++ b/apps/hearthly-api/src/main.ts
@@ -1,10 +1,11 @@
 import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
+import helmet from 'helmet';
 import { AppModule } from './app/app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.getHttpAdapter().getInstance().disable('x-powered-by');
+  app.use(helmet());
   app.enableShutdownHooks();
   const globalPrefix = 'api';
   app.setGlobalPrefix(globalPrefix);

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
         "@nestjs/platform-express": "^11.0.0",
         "@nestjs/terminus": "^11.1.1",
         "drizzle-orm": "^0.45.1",
+        "helmet": "^8.1.0",
         "nestjs-cls": "^6.2.0",
         "postgres": "^3.4.8",
         "reflect-metadata": "^0.1.13",
@@ -19162,6 +19163,15 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/homedir-polyfill": {


### PR DESCRIPTION
## Summary
- Install `helmet` and add as Express middleware in `main.ts`
- Replaces manual `x-powered-by` disable — helmet handles it plus adds X-Content-Type-Options, X-Frame-Options, Strict-Transport-Security, etc.

## Test plan
- [ ] API builds successfully
- [ ] Health endpoint responds with security headers