### PR TITLE
feat(api): configure CORS with environment-based origin (#27)

### DIFF
--- a/apps/hearthly-api/src/main.ts
+++ b/apps/hearthly-api/src/main.ts
@@ -6,6 +6,9 @@ import { AppModule } from './app/app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.use(helmet());
+  app.enableCors({
+    origin: process.env.CORS_ORIGIN || 'http://localhost:4200',
+  });
   app.enableShutdownHooks();
   const globalPrefix = 'api';
   app.setGlobalPrefix(globalPrefix);


### PR DESCRIPTION
## Summary
- Add `app.enableCors()` with configurable origin via `CORS_ORIGIN` env var
- Defaults to `http://localhost:4200` (Angular dev server) for local development
- Production: set `CORS_ORIGIN=https://hearthly.dev`

## Test plan
- [ ] API builds successfully
- [ ] Local dev: Angular app on port 4200 can call API on port 3000 without CORS errors