### PR TITLE
fix(keycloak): post-deploy hardening — memory, metrics, network policy

### DIFF
--- a/infrastructure/cluster-services/keycloak/templates/deployment.yaml
+++ b/infrastructure/cluster-services/keycloak/templates/deployment.yaml
@@ -64,6 +64,8 @@ spec:
               value: "true"
             - name: KC_CACHE
               value: "local"
+            - name: KC_METRICS_ENABLED
+              value: "true"
             # Admin bootstrap (first startup only)
             - name: KC_BOOTSTRAP_ADMIN_USERNAME
               value: {{ .Values.keycloak.admin.username | quote }}

--- a/infrastructure/cluster-services/keycloak/templates/networkpolicy.yaml
+++ b/infrastructure/cluster-services/keycloak/templates/networkpolicy.yaml
@@ -1,0 +1,39 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "keycloak.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow traffic from Traefik ingress controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: traefik
+      ports:
+        - port: http
+          protocol: TCP
+  egress:
+    # Allow DNS resolution
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow traffic to keycloak-db (same namespace)
+    - to:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: keycloak-db
+      ports:
+        - port: 5432
+          protocol: TCP

--- a/infrastructure/cluster-services/keycloak/values.yaml
+++ b/infrastructure/cluster-services/keycloak/values.yaml
@@ -19,10 +19,10 @@ ingress:
 resources:
   requests:
     cpu: 250m
-    memory: 512Mi
+    memory: 768Mi
   limits:
     cpu: "1"
-    memory: 1Gi
+    memory: 1536Mi
 
 keycloak:
   hostname: "https://auth.hearthly.dev"


### PR DESCRIPTION
## Summary
Post-deployment hardening based on review findings:

- **Memory limit raised** from 1Gi to 1536Mi (request from 512Mi to 768Mi) — idle usage is ~500Mi, 1Gi would OOMKill under real auth traffic
- **Prometheus metrics enabled** (`KC_METRICS_ENABLED=true`) — exposes `/metrics` on management port 9000 for the existing Prometheus stack
- **NetworkPolicy added** — restricts Keycloak pods to: ingress from Traefik only, egress to keycloak-db (PostgreSQL) and DNS only
- **PV reclaim policy** patched to `Retain` in-cluster (was `Delete` — risk of data loss)

## Test plan
- [x] Helm template renders 5 resources (Deployment, Service, Ingress, InfisicalSecret, NetworkPolicy)
- [x] PV reclaim policy verified as Retain in cluster
- [ ] ArgoCD syncs successfully
- [ ] Keycloak pod restarts with new memory limits
- [ ] NetworkPolicy doesn't break Keycloak ↔ DB or Traefik ↔ Keycloak traffic