### PR TITLE
feat(keycloak): add backup CronJob for Keycloak database (#35)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,18 @@ Family management app. See `docs/project-summary.md` for architecture decisions 
 - **Restore:** `aws s3 cp s3://hearthly-backups/<filename>.dump . --endpoint-url https://nbg1.your-objectstorage.com --region nbg1 && pg_restore -d "$(kubectl get secret hearthly-db-app -n hearthly -o jsonpath='{.data.uri}' | base64 -d)" <filename>.dump`
 - **Verify checksum:** `aws s3 cp s3://hearthly-backups/<filename>.dump.sha256 . --endpoint-url https://nbg1.your-objectstorage.com --region nbg1 && sha256sum -c <filename>.dump.sha256`
 
+## Database — Keycloak
+
+- **Cluster:** keycloak-db in keycloak namespace, PostgreSQL (same operator as hearthly-db)
+- **Storage:** 5Gi Hetzner Volume
+- **Credentials:** Auto-generated in K8s Secret `keycloak-db-app`
+- **Connection URI:** `kubectl get secret keycloak-db-app -n keycloak -o jsonpath='{.data.uri}' | base64 -d`
+- **Backups:** Daily pg_dump CronJob at 03:00 UTC → same `hearthly-backups` bucket, prefix `keycloak-db-`
+- **S3 credentials:** Infisical → `keycloak-s3-credentials` K8s Secret in keycloak namespace
+- **Restore:** `aws s3 cp s3://hearthly-backups/<filename>.dump . --endpoint-url https://nbg1.your-objectstorage.com --region nbg1 && pg_restore -d "$(kubectl get secret keycloak-db-app -n keycloak -o jsonpath='{.data.uri}' | base64 -d)" <filename>.dump`
+- **Verify checksum:** `aws s3 cp s3://hearthly-backups/<filename>.dump.sha256 . --endpoint-url https://nbg1.your-objectstorage.com --region nbg1 && sha256sum -c <filename>.dump.sha256`
+- **Manual trigger:** `kubectl create job --from=cronjob/keycloak-db-backup manual-keycloak-backup -n keycloak`
+
 ## Build & Run Commands
 
 ```bash

--- a/infrastructure/cluster-services/keycloak/templates/cronjob-db-backup.yaml
+++ b/infrastructure/cluster-services/keycloak/templates/cronjob-db-backup.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: keycloak-db-backup
+  name: {{ .Chart.Name }}-db-backup
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
 spec:

--- a/infrastructure/cluster-services/keycloak/templates/cronjob-db-backup.yaml
+++ b/infrastructure/cluster-services/keycloak/templates/cronjob-db-backup.yaml
@@ -1,0 +1,138 @@
+{{- if .Values.backup.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: keycloak-db-backup
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 600
+      template:
+        metadata:
+          labels:
+            {{- include "keycloak.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: db-backup
+        spec:
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          restartPolicy: OnFailure
+          volumes:
+            - name: backup-data
+              emptyDir: {}
+            - name: tmp
+              emptyDir: {}
+          initContainers:
+            # Step 1: pg_dump with custom format (supports parallel restore)
+            - name: dump
+              image: {{ .Values.backup.images.dump }}
+              securityContext:
+                runAsUser: 70
+                runAsGroup: 70
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: keycloak-db-app
+                      key: uri
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eo pipefail
+                  TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+                  echo "${TIMESTAMP}" > /backup/timestamp
+                  FILENAME="keycloak-db-${TIMESTAMP}.dump"
+
+                  echo "Dumping database: ${FILENAME}"
+                  pg_dump "${DATABASE_URL}" --format=custom > "/backup/${FILENAME}"
+
+                  FILESIZE=$(stat -c%s "/backup/${FILENAME}" 2>/dev/null || echo 0)
+                  if [ "$FILESIZE" -lt 100 ]; then
+                    echo "ERROR: Backup file too small (${FILESIZE} bytes). Aborting."
+                    exit 1
+                  fi
+                  echo "Dump complete: $(du -h /backup/${FILENAME} | cut -f1)"
+
+                  echo "Generating checksum"
+                  sha256sum "/backup/${FILENAME}" > "/backup/${FILENAME}.sha256"
+                  cat "/backup/${FILENAME}.sha256"
+              volumeMounts:
+                - name: backup-data
+                  mountPath: /backup
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 256Mi
+          containers:
+            # Step 2: Upload to S3 (lifecycle policy handles retention)
+            - name: upload
+              image: {{ .Values.backup.images.upload }}
+              securityContext:
+                runAsUser: 1000
+                runAsGroup: 1000
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              env:
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: keycloak-s3-credentials
+                      key: S3_ACCESS_KEY
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: keycloak-s3-credentials
+                      key: S3_SECRET_KEY
+                - name: S3_BUCKET
+                  value: {{ .Values.backup.s3.bucket | quote }}
+                - name: S3_ENDPOINT
+                  value: {{ .Values.backup.s3.endpoint | quote }}
+                - name: S3_REGION
+                  value: {{ .Values.backup.s3.region | quote }}
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  TIMESTAMP=$(cat /backup/timestamp)
+                  FILENAME="keycloak-db-${TIMESTAMP}.dump"
+
+                  echo "Uploading /backup/${FILENAME} to s3://${S3_BUCKET}/"
+                  aws s3 cp "/backup/${FILENAME}" "s3://${S3_BUCKET}/${FILENAME}" \
+                    --endpoint-url "${S3_ENDPOINT}" \
+                    --region "${S3_REGION}"
+                  aws s3 cp "/backup/${FILENAME}.sha256" "s3://${S3_BUCKET}/${FILENAME}.sha256" \
+                    --endpoint-url "${S3_ENDPOINT}" \
+                    --region "${S3_REGION}"
+                  echo "Upload complete (backup + checksum)"
+              volumeMounts:
+                - name: backup-data
+                  mountPath: /backup
+                - name: tmp
+                  mountPath: /tmp
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 200m
+                  memory: 128Mi
+{{- end }}

--- a/infrastructure/cluster-services/keycloak/templates/infisical-s3-secret.yaml
+++ b/infrastructure/cluster-services/keycloak/templates/infisical-s3-secret.yaml
@@ -1,0 +1,25 @@
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: keycloak-s3-credentials
+  namespace: {{ .Release.Namespace }}
+spec:
+  hostAPI: "http://infisical-infisical-standalone-infisical.infisical.svc.cluster.local:8080/api"
+  resyncInterval: 60
+  authentication:
+    universalAuth:
+      credentialsRef:
+        secretName: infisical-machine-identity
+        secretNamespace: hearthly
+      secretsScope:
+        envSlug: prod
+        projectId: "8e2b05b0-c7e7-4e4c-89a7-90bba3e8c705"
+        secretsPath: "/"
+  managedSecretReference:
+    secretName: keycloak-s3-credentials
+    secretNamespace: {{ .Release.Namespace }}
+    creationPolicy: Orphan
+    template:
+      data:
+        S3_ACCESS_KEY: "{{ `{{ .S3_ACCESS_KEY.Value }}` }}"
+        S3_SECRET_KEY: "{{ `{{ .S3_SECRET_KEY.Value }}` }}"

--- a/infrastructure/cluster-services/keycloak/values.yaml
+++ b/infrastructure/cluster-services/keycloak/values.yaml
@@ -35,3 +35,14 @@ keycloak:
     username: "admin"
     existingSecret: "keycloak-admin-credentials"
     passwordKey: "admin-password"
+
+backup:
+  enabled: true
+  schedule: "0 3 * * *"  # Daily at 03:00 UTC (1h after app backup)
+  images:
+    dump: postgres:18-alpine
+    upload: amazon/aws-cli:2.27.31
+  s3:
+    bucket: hearthly-backups
+    endpoint: https://nbg1.your-objectstorage.com
+    region: nbg1


### PR DESCRIPTION
## Summary

- Add daily pg_dump CronJob for Keycloak CloudNativePG database, mirroring the proven app DB backup pattern
- New InfisicalSecret syncs S3 credentials from Infisical into keycloak namespace
- Backup runs at 03:00 UTC (offset from app backup at 02:00) to `hearthly-backups` bucket with `keycloak-db-` prefix
- CLAUDE.md updated with Keycloak DB restore instructions and manual trigger

Closes #35

## Test plan

- [ ] `helm template` renders cleanly (verified locally)
- [ ] CI passes (lint, build)
- [ ] ArgoCD syncs new CronJob to keycloak namespace
- [ ] InfisicalSecret creates `keycloak-s3-credentials` K8s Secret in keycloak namespace
- [ ] Manual trigger: `kubectl create job --from=cronjob/keycloak-db-backup manual-keycloak-backup -n keycloak`
- [ ] Verify backup appears in `s3://hearthly-backups/` with `keycloak-db-` prefix
- [ ] Grafana "Backup Failed" and "Last Backup Age" panels pick up keycloak backup (regex `.*db-backup.*`)