### PR TITLE
feat: Google sign-in with kc_idp_hint, social-only auth (#61)

### DIFF
--- a/apps/hearthly-app/src/app/auth/auth.service.spec.ts
+++ b/apps/hearthly-app/src/app/auth/auth.service.spec.ts
@@ -1,0 +1,49 @@
+import { TestBed } from '@angular/core/testing';
+import { OAuthService } from 'angular-oauth2-oidc';
+import { AuthService } from './auth.service';
+import { MeGQL } from '../../generated/graphql';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let mockOAuthService: {
+    initCodeFlow: ReturnType<typeof vi.fn>;
+    configure: ReturnType<typeof vi.fn>;
+    loadDiscoveryDocumentAndTryLogin: ReturnType<typeof vi.fn>;
+    hasValidAccessToken: ReturnType<typeof vi.fn>;
+    setupAutomaticSilentRefresh: ReturnType<typeof vi.fn>;
+    logOut: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    mockOAuthService = {
+      initCodeFlow: vi.fn(),
+      configure: vi.fn(),
+      loadDiscoveryDocumentAndTryLogin: vi.fn().mockResolvedValue(true),
+      hasValidAccessToken: vi.fn().mockReturnValue(false),
+      setupAutomaticSilentRefresh: vi.fn(),
+      logOut: vi.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        AuthService,
+        { provide: OAuthService, useValue: mockOAuthService },
+        { provide: MeGQL, useValue: { fetch: vi.fn() } },
+      ],
+    });
+
+    service = TestBed.inject(AuthService);
+  });
+
+  describe('login()', () => {
+    it('should call initCodeFlow with kc_idp_hint when idpHint is provided', () => {
+      service.login('google');
+      expect(mockOAuthService.initCodeFlow).toHaveBeenCalledWith('', { kc_idp_hint: 'google' });
+    });
+
+    it('should call initCodeFlow without args when no idpHint is provided', () => {
+      service.login();
+      expect(mockOAuthService.initCodeFlow).toHaveBeenCalledWith();
+    });
+  });
+});

--- a/apps/hearthly-app/src/app/auth/auth.service.ts
+++ b/apps/hearthly-app/src/app/auth/auth.service.ts
@@ -47,8 +47,12 @@ export class AuthService {
     this.oauthService.setupAutomaticSilentRefresh();
   }
 
-  login(): void {
-    this.oauthService.initCodeFlow();
+  login(idpHint?: string): void {
+    if (idpHint) {
+      this.oauthService.initCodeFlow('', { kc_idp_hint: idpHint });
+    } else {
+      this.oauthService.initCodeFlow();
+    }
   }
 
   logout(): void {

--- a/apps/hearthly-app/src/app/welcome/welcome.component.html
+++ b/apps/hearthly-app/src/app/welcome/welcome.component.html
@@ -12,8 +12,8 @@
     <p class="welcome-tagline">Your household, together</p>
 
     <div class="welcome-buttons">
-      <button class="google-sign-in" data-testid="sign-in-google" (click)="signInWithGoogle()">
-        <svg class="google-icon" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+      <button type="button" class="google-sign-in" data-testid="sign-in-google" (click)="signInWithGoogle()">
+        <svg class="google-icon" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
           <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615Z" fill="#4285F4"/>
           <path d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18Z" fill="#34A853"/>
           <path d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.997 8.997 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332Z" fill="#FBBC05"/>

--- a/apps/hearthly-app/src/app/welcome/welcome.component.html
+++ b/apps/hearthly-app/src/app/welcome/welcome.component.html
@@ -10,8 +10,23 @@
     </div>
     <h1 class="welcome-title">Hearthly</h1>
     <p class="welcome-tagline">Your household, together</p>
-    <ion-button expand="block" data-testid="sign-in-button" (click)="signIn()">
-      Sign in
-    </ion-button>
+
+    <div class="welcome-buttons">
+      <button class="google-sign-in" data-testid="sign-in-google" (click)="signInWithGoogle()">
+        <svg class="google-icon" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+          <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615Z" fill="#4285F4"/>
+          <path d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18Z" fill="#34A853"/>
+          <path d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.997 8.997 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332Z" fill="#FBBC05"/>
+          <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 6.29C4.672 4.163 6.656 2.58 9 3.58Z" fill="#EA4335"/>
+        </svg>
+        <span>Sign in with Google</span>
+      </button>
+
+      @if (showPasswordAuth) {
+        <ion-button expand="block" fill="outline" size="small" data-testid="sign-in-password" (click)="signIn()">
+          Sign in with email (dev)
+        </ion-button>
+      }
+    </div>
   </div>
 </ion-content>

--- a/apps/hearthly-app/src/app/welcome/welcome.component.scss
+++ b/apps/hearthly-app/src/app/welcome/welcome.component.scss
@@ -25,8 +25,73 @@
   margin: 0 0 48px;
 }
 
-ion-button {
+.welcome-buttons {
   width: 100%;
   max-width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+// Google Sign-In button — follows Google Branding Guidelines
+// https://developers.google.com/identity/branding-guidelines
+.google-sign-in {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  width: 100%;
+  padding: 14px 16px;
+  border: 1px solid #dadce0;
+  border-radius: var(--hearthly-radius-button);
+  background: #ffffff;
+  color: #3c4043;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+
+  &:hover {
+    background: #f7f8f8;
+    border-color: #c4c7c5;
+  }
+
+  &:active {
+    background: #e8eaed;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--ion-color-primary);
+    outline-offset: 2px;
+  }
+}
+
+.google-icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+// Dev-only fallback button
+ion-button {
   --border-radius: var(--hearthly-radius-button);
+}
+
+// Dark mode — Google brand colors for dark theme
+@media (prefers-color-scheme: dark) {
+  .google-sign-in {
+    background: #131314;
+    border-color: #8e918f;
+    color: #e3e3e3;
+
+    &:hover {
+      background: #1f1f20;
+      border-color: #a1a3a0;
+    }
+
+    &:active {
+      background: #2a2a2b;
+    }
+  }
 }

--- a/apps/hearthly-app/src/app/welcome/welcome.component.spec.ts
+++ b/apps/hearthly-app/src/app/welcome/welcome.component.spec.ts
@@ -3,6 +3,7 @@ import { signal, computed } from '@angular/core';
 import { provideRouter, Router } from '@angular/router';
 import { WelcomeComponent } from './welcome.component';
 import { AuthService } from '../auth/auth.service';
+import { environment } from '../../environments/environment';
 
 describe('WelcomeComponent', () => {
   const mockAuthService = {
@@ -11,6 +12,8 @@ describe('WelcomeComponent', () => {
     isLoading: signal(false),
     error: signal<string | null>(null),
     initials: computed(() => ''),
+    displayName: computed(() => ''),
+    pictureUrl: computed(() => null),
     login: vi.fn(),
     logout: vi.fn(),
     retry: vi.fn(),
@@ -33,12 +36,49 @@ describe('WelcomeComponent', () => {
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('should call authService.login() when sign in is clicked', () => {
+  it('should call authService.login("google") when Google sign-in is clicked', () => {
     const fixture = TestBed.createComponent(WelcomeComponent);
     fixture.detectChanges();
-    const button: HTMLElement = fixture.nativeElement.querySelector('ion-button[data-testid="sign-in-button"]');
+    const button: HTMLElement = fixture.nativeElement.querySelector('[data-testid="sign-in-google"]');
     button.click();
-    expect(mockAuthService.login).toHaveBeenCalled();
+    expect(mockAuthService.login).toHaveBeenCalledWith('google');
+  });
+
+  it('should show dev fallback button when enablePasswordAuth is true', () => {
+    const original = environment.enablePasswordAuth;
+    (environment as any).enablePasswordAuth = true;
+
+    const fixture = TestBed.createComponent(WelcomeComponent);
+    fixture.detectChanges();
+    const button: HTMLElement = fixture.nativeElement.querySelector('[data-testid="sign-in-password"]');
+    expect(button).toBeTruthy();
+
+    (environment as any).enablePasswordAuth = original;
+  });
+
+  it('should hide dev fallback button when enablePasswordAuth is false', () => {
+    const original = environment.enablePasswordAuth;
+    (environment as any).enablePasswordAuth = false;
+
+    const fixture = TestBed.createComponent(WelcomeComponent);
+    fixture.detectChanges();
+    const button: HTMLElement = fixture.nativeElement.querySelector('[data-testid="sign-in-password"]');
+    expect(button).toBeFalsy();
+
+    (environment as any).enablePasswordAuth = original;
+  });
+
+  it('should call authService.login() without args when dev fallback is clicked', () => {
+    const original = environment.enablePasswordAuth;
+    (environment as any).enablePasswordAuth = true;
+
+    const fixture = TestBed.createComponent(WelcomeComponent);
+    fixture.detectChanges();
+    const button: HTMLElement = fixture.nativeElement.querySelector('[data-testid="sign-in-password"]');
+    button.click();
+    expect(mockAuthService.login).toHaveBeenCalledWith();
+
+    (environment as any).enablePasswordAuth = original;
   });
 
   it('should redirect to /app/home if already authenticated', () => {
@@ -48,6 +88,8 @@ describe('WelcomeComponent', () => {
       isLoading: signal(false),
       error: signal<string | null>(null),
       initials: computed(() => 'T'),
+      displayName: computed(() => 'Test'),
+      pictureUrl: computed(() => null),
       login: vi.fn(),
       logout: vi.fn(),
       retry: vi.fn(),

--- a/apps/hearthly-app/src/app/welcome/welcome.component.spec.ts
+++ b/apps/hearthly-app/src/app/welcome/welcome.component.spec.ts
@@ -47,38 +47,41 @@ describe('WelcomeComponent', () => {
   it('should show dev fallback button when enablePasswordAuth is true', () => {
     const original = environment.enablePasswordAuth;
     (environment as any).enablePasswordAuth = true;
-
-    const fixture = TestBed.createComponent(WelcomeComponent);
-    fixture.detectChanges();
-    const button: HTMLElement = fixture.nativeElement.querySelector('[data-testid="sign-in-password"]');
-    expect(button).toBeTruthy();
-
-    (environment as any).enablePasswordAuth = original;
+    try {
+      const fixture = TestBed.createComponent(WelcomeComponent);
+      fixture.detectChanges();
+      const button: HTMLElement = fixture.nativeElement.querySelector('[data-testid="sign-in-password"]');
+      expect(button).toBeTruthy();
+    } finally {
+      (environment as any).enablePasswordAuth = original;
+    }
   });
 
   it('should hide dev fallback button when enablePasswordAuth is false', () => {
     const original = environment.enablePasswordAuth;
     (environment as any).enablePasswordAuth = false;
-
-    const fixture = TestBed.createComponent(WelcomeComponent);
-    fixture.detectChanges();
-    const button: HTMLElement = fixture.nativeElement.querySelector('[data-testid="sign-in-password"]');
-    expect(button).toBeFalsy();
-
-    (environment as any).enablePasswordAuth = original;
+    try {
+      const fixture = TestBed.createComponent(WelcomeComponent);
+      fixture.detectChanges();
+      const button: HTMLElement = fixture.nativeElement.querySelector('[data-testid="sign-in-password"]');
+      expect(button).toBeFalsy();
+    } finally {
+      (environment as any).enablePasswordAuth = original;
+    }
   });
 
   it('should call authService.login() without args when dev fallback is clicked', () => {
     const original = environment.enablePasswordAuth;
     (environment as any).enablePasswordAuth = true;
-
-    const fixture = TestBed.createComponent(WelcomeComponent);
-    fixture.detectChanges();
-    const button: HTMLElement = fixture.nativeElement.querySelector('[data-testid="sign-in-password"]');
-    button.click();
-    expect(mockAuthService.login).toHaveBeenCalledWith();
-
-    (environment as any).enablePasswordAuth = original;
+    try {
+      const fixture = TestBed.createComponent(WelcomeComponent);
+      fixture.detectChanges();
+      const button: HTMLElement = fixture.nativeElement.querySelector('[data-testid="sign-in-password"]');
+      button.click();
+      expect(mockAuthService.login).toHaveBeenCalledWith();
+    } finally {
+      (environment as any).enablePasswordAuth = original;
+    }
   });
 
   it('should redirect to /app/home if already authenticated', () => {

--- a/apps/hearthly-app/src/app/welcome/welcome.component.ts
+++ b/apps/hearthly-app/src/app/welcome/welcome.component.ts
@@ -2,6 +2,7 @@ import { Component, inject, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { IonContent, IonButton } from '@ionic/angular/standalone';
 import { AuthService } from '../auth/auth.service';
+import { environment } from '../../environments/environment';
 
 @Component({
   selector: 'app-welcome',
@@ -13,10 +14,16 @@ export class WelcomeComponent implements OnInit {
   private readonly authService = inject(AuthService);
   private readonly router = inject(Router);
 
+  readonly showPasswordAuth = environment.enablePasswordAuth;
+
   ngOnInit(): void {
     if (this.authService.isAuthenticated()) {
       this.router.navigate(['/app/home']);
     }
+  }
+
+  signInWithGoogle(): void {
+    this.authService.login('google');
   }
 
   signIn(): void {

--- a/apps/hearthly-app/src/environments/environment.interface.ts
+++ b/apps/hearthly-app/src/environments/environment.interface.ts
@@ -1,5 +1,6 @@
 export interface Environment {
   production: boolean;
+  enablePasswordAuth: boolean;
   keycloak: {
     issuer: string;
     clientId: string;

--- a/apps/hearthly-app/src/environments/environment.prod.ts
+++ b/apps/hearthly-app/src/environments/environment.prod.ts
@@ -2,6 +2,7 @@ import type { Environment } from './environment.interface';
 
 export const environment: Environment = {
   production: true,
+  enablePasswordAuth: false,
   keycloak: {
     issuer: 'https://auth.hearthly.dev/realms/hearthly',
     clientId: 'hearthly-app',

--- a/apps/hearthly-app/src/environments/environment.ts
+++ b/apps/hearthly-app/src/environments/environment.ts
@@ -3,6 +3,7 @@ import type { Environment } from './environment.interface';
 
 export const environment: Environment = {
   production: false,
+  enablePasswordAuth: true,
   keycloak: {
     issuer: 'http://localhost:8180/realms/hearthly',
     clientId: 'hearthly-app',

--- a/infrastructure/cluster-services/keycloak/deploy/themes/hearthly/login/error.ftl
+++ b/infrastructure/cluster-services/keycloak/deploy/themes/hearthly/login/error.ftl
@@ -2,12 +2,12 @@
 <@layout.registrationLayout displayMessage=false displayInfo=false; section>
 
     <#if section = "header">
-        Please use the Hearthly app
+        Please use the Hearthly app to sign in
 
     <#elseif section = "form">
         <div class="hearthly-form" style="text-align: center;">
             <p style="color: var(--hearthly-text-muted); font-size: 15px; margin-bottom: 24px;">
-                Direct login is not available. Open the Hearthly app to sign in.
+                Direct login is not available. Open the Hearthly app to continue.
             </p>
         </div>
     </#if>

--- a/infrastructure/cluster-services/keycloak/deploy/themes/hearthly/login/error.ftl
+++ b/infrastructure/cluster-services/keycloak/deploy/themes/hearthly/login/error.ftl
@@ -1,0 +1,15 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=false displayInfo=false; section>
+
+    <#if section = "header">
+        Please use the Hearthly app
+
+    <#elseif section = "form">
+        <div class="hearthly-form" style="text-align: center;">
+            <p style="color: var(--hearthly-text-muted); font-size: 15px; margin-bottom: 24px;">
+                Direct login is not available. Open the Hearthly app to sign in.
+            </p>
+        </div>
+    </#if>
+
+</@layout.registrationLayout>

--- a/infrastructure/keycloak-config/authentication.tf
+++ b/infrastructure/keycloak-config/authentication.tf
@@ -1,0 +1,37 @@
+# --- Social-Only Browser Flow ---
+# Custom browser flow that removes the username/password form entirely.
+# Only Cookie (session check) and Identity Provider Redirector (kc_idp_hint)
+# remain. Users must come through the app with kc_idp_hint — direct Keycloak
+# access without a hint shows the custom error page (error.ftl).
+#
+# Forward-compatible with multiple IdPs (Apple #33): each app button passes
+# its own kc_idp_hint, no flow changes needed.
+
+resource "keycloak_authentication_flow" "social_only_browser" {
+  realm_id = keycloak_realm.hearthly.id
+  alias    = "social-only-browser"
+}
+
+resource "keycloak_authentication_execution" "social_browser_cookie" {
+  realm_id          = keycloak_realm.hearthly.id
+  parent_flow_alias = keycloak_authentication_flow.social_only_browser.alias
+  authenticator     = "auth-cookie"
+  requirement       = "ALTERNATIVE"
+}
+
+resource "keycloak_authentication_execution" "social_browser_idp_redirector" {
+  realm_id          = keycloak_realm.hearthly.id
+  parent_flow_alias = keycloak_authentication_flow.social_only_browser.alias
+  authenticator     = "identity-provider-redirector"
+  requirement       = "ALTERNATIVE"
+
+  depends_on = [keycloak_authentication_execution.social_browser_cookie]
+}
+
+# Bind the social-only flow as the realm's browser flow.
+# Uses keycloak_authentication_bindings (not browser_flow on keycloak_realm)
+# to avoid a known cyclic dependency issue in the Terraform provider.
+resource "keycloak_authentication_bindings" "browser_binding" {
+  realm_id     = keycloak_realm.hearthly.id
+  browser_flow = keycloak_authentication_flow.social_only_browser.alias
+}

--- a/infrastructure/keycloak-config/identity-providers.tf
+++ b/infrastructure/keycloak-config/identity-providers.tf
@@ -34,8 +34,8 @@ resource "keycloak_oidc_google_identity_provider" "google" {
   client_id     = var.google_client_id
   client_secret = var.google_client_secret
 
-  trust_email   = true
-  sync_mode     = "FORCE"
+  trust_email = true
+  sync_mode   = "FORCE"
 
   default_scopes = "openid email profile"
 

--- a/infrastructure/keycloak-config/realm.tf
+++ b/infrastructure/keycloak-config/realm.tf
@@ -4,11 +4,11 @@ resource "keycloak_realm" "hearthly" {
   display_name = "Hearthly"
 
   # Login settings
-  registration_allowed           = true
+  registration_allowed           = false
   registration_email_as_username = true
   login_with_email_allowed       = true
   duplicate_emails_allowed       = false
-  reset_password_allowed         = true
+  reset_password_allowed         = false
   remember_me                    = false
 
   # Login theme


### PR DESCRIPTION
## Summary

- Replace generic "Sign in" button with Google-branded "Sign in with Google" button using `kc_idp_hint` to bypass Keycloak login page entirely
- Add `enablePasswordAuth` environment flag — dev shows password fallback, prod shows Google only
- Create custom Keycloak browser flow (Cookie + IdP Redirector) removing password form completely
- Disable self-registration and password reset in prod Keycloak realm
- Add branded error page for direct Keycloak access without `kc_idp_hint`

## Keycloak changes

- **`authentication.tf`**: New `social-only-browser` flow with Cookie (session check) + Identity Provider Redirector (handles `kc_idp_hint`). No password form.
- **`realm.tf`**: `registration_allowed = false`, `reset_password_allowed = false`
- **`error.ftl`**: Custom themed error page — "Please use the Hearthly app to sign in"
- Forward-compatible with Apple Sign-In (#33) — no flow changes needed, just add a button with `kc_idp_hint: 'apple'`

## Deployment note

The `error.ftl` theme change and Terraform changes ship via different pipelines. The Keycloak image should deploy before `terraform apply` runs. Both trigger on merge to main — the image build is typically faster than the Terraform plan+apply cycle, so ordering should be natural.

## Test plan

- [x] All 33 frontend tests pass (WelcomeComponent: 6 tests, AuthService: 2 tests, auth guard: 4 tests)
- [x] All 32 API tests pass (regression check)
- [x] Frontend lint clean, build succeeds
- [x] Terraform fmt clean
- [ ] CI passes (lint, test, build)
- [ ] Keycloak image deploys with new error page
- [ ] Terraform applies (social-only browser flow)
- [ ] Verify Google sign-in works on prod (hearthly.dev)
- [ ] Verify direct Keycloak access (auth.hearthly.dev) shows error page

Closes #61