### PR TITLE
fix(keycloak): upgrade to 26.5.5 for CVE-2026-2092 (#68)

### DIFF
--- a/infrastructure/cluster-services/keycloak/deploy/Dockerfile
+++ b/infrastructure/cluster-services/keycloak/deploy/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage — runs kc.sh build to pre-compile Quarkus augmentation
-FROM quay.io/keycloak/keycloak:26.3.3 AS builder
+FROM quay.io/keycloak/keycloak:26.5.5 AS builder
 
 WORKDIR /opt/keycloak
 
@@ -13,7 +13,7 @@ ENV KC_CACHE=local
 RUN /opt/keycloak/bin/kc.sh build
 
 # Production stage — contains pre-built optimized artifacts
-FROM quay.io/keycloak/keycloak:26.3.3
+FROM quay.io/keycloak/keycloak:26.5.5
 
 LABEL org.opencontainers.image.source=https://github.com/rudingma/hearthly
 


### PR DESCRIPTION
## Summary

- Upgrade Keycloak from 26.3.3 to 26.5.5 in the Dockerfile (both builder and production stages)
- Fixes CVE-2026-2092 (HIGH) in `keycloak-saml-core` and `keycloak-services`
- Unblocks the custom `error.ftl` theme from #61 which couldn't deploy due to Trivy scan failure

## Test plan

- [ ] CI passes
- [ ] Keycloak image builds and passes Trivy scan
- [ ] Keycloak pod starts and is healthy after deploy
- [ ] Google sign-in still works
- [ ] Custom error page visible at direct Keycloak access

Closes #68