### PR TITLE
feat(app): Content-Security-Policy on nginx (#26)

### DIFF
--- a/apps/hearthly-app/deploy/Dockerfile
+++ b/apps/hearthly-app/deploy/Dockerfile
@@ -23,8 +23,17 @@ FROM nginxinc/nginx-unprivileged:alpine
 
 LABEL org.opencontainers.image.source=https://github.com/rudingma/hearthly
 
-# Copy nginx config and built static files
-COPY apps/hearthly-app/deploy/nginx.conf /etc/nginx/nginx.conf
+# envsubst template config:
+# - NGINX_ENVSUBST_OUTPUT_DIR: process template to /etc/nginx/ (replaces main nginx.conf)
+# - NGINX_ENVSUBST_FILTER: only substitute CSP_* vars (protects nginx vars like $uri)
+# - CSP defaults: safety net if Helm env vars are misconfigured
+ENV NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx \
+    NGINX_ENVSUBST_FILTER="^CSP_" \
+    CSP_API_ORIGIN="https://api.hearthly.dev" \
+    CSP_AUTH_ORIGIN="https://auth.hearthly.dev"
+
+# Copy nginx template and built static files
+COPY apps/hearthly-app/deploy/nginx.conf.template /etc/nginx/templates/nginx.conf.template
 COPY --from=builder /app/dist/apps/hearthly-app/browser/ /usr/share/nginx/html/
 
 EXPOSE 8080

--- a/apps/hearthly-app/deploy/chart/templates/deployment.yaml
+++ b/apps/hearthly-app/deploy/chart/templates/deployment.yaml
@@ -27,6 +27,11 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: CSP_API_ORIGIN
+              value: {{ .Values.csp.apiOrigin | quote }}
+            - name: CSP_AUTH_ORIGIN
+              value: {{ .Values.csp.authOrigin | quote }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/apps/hearthly-app/deploy/chart/values.yaml
+++ b/apps/hearthly-app/deploy/chart/values.yaml
@@ -19,3 +19,7 @@ resources:
   limits:
     cpu: 200m
     memory: 64Mi
+
+csp:
+  apiOrigin: "https://api.hearthly.dev"
+  authOrigin: "https://auth.hearthly.dev"

--- a/apps/hearthly-app/deploy/nginx.conf.template
+++ b/apps/hearthly-app/deploy/nginx.conf.template
@@ -34,6 +34,7 @@ http {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "DENY" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://lh3.googleusercontent.com; font-src 'self'; connect-src 'self' ${CSP_API_ORIGIN} ${CSP_AUTH_ORIGIN}; frame-ancestors 'none'; form-action 'self'; base-uri 'self'; object-src 'none'; upgrade-insecure-requests" always;
 
         # Cache hashed static assets aggressively (uses expires only,
         # so security headers from the server block are inherited)


### PR DESCRIPTION
## Summary

- Add `Content-Security-Policy` header to the frontend nginx config with a tight, explicit allowlist of origins
- Use nginx's built-in `envsubst` template mechanism so CSP origins are configurable per environment (prod, staging, etc.) via Helm values
- Configure `NGINX_ENVSUBST_FILTER="^CSP_"` to prevent collisions with nginx variables like `$uri`
- Dockerfile defaults to production origins as a safety net

## CSP Directives

`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://lh3.googleusercontent.com; font-src 'self'; connect-src 'self' <api> <auth>; frame-ancestors 'none'; form-action 'self'; base-uri 'self'; object-src 'none'; upgrade-insecure-requests`

## Files Changed

- `apps/hearthly-app/deploy/nginx.conf` → `nginx.conf.template` (renamed, CSP header added)
- `apps/hearthly-app/deploy/Dockerfile` (envsubst template mechanism)
- `apps/hearthly-app/deploy/chart/templates/deployment.yaml` (CSP env vars)
- `apps/hearthly-app/deploy/chart/values.yaml` (CSP origin defaults)

## Test Plan

- [x] Helm template renders CSP env vars correctly
- [x] Docker build succeeds
- [x] CSP header present with default (production) origins
- [x] Env var override works (staging origins substituted)
- [x] Existing security headers preserved (X-Content-Type-Options, X-Frame-Options, Referrer-Policy)
- [x] SPA fallback works (`$uri` not broken by envsubst)

Closes #26