### PR TITLE
feat(infra): NetworkPolicy for namespace isolation (#28)

### DIFF
--- a/apps/hearthly-api/deploy/chart/templates/networkpolicy-db.yaml
+++ b/apps/hearthly-api/deploy/chart/templates/networkpolicy-db.yaml
@@ -1,0 +1,39 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hearthly-db
+  labels:
+    {{- include "hearthly-api.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: hearthly-db
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow traffic from hearthly-api (PostgreSQL queries)
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ .Chart.Name }}
+      ports:
+        - port: 5432
+          protocol: TCP
+    # Allow traffic from CNPG operator (management + status)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cnpg-system
+      ports:
+        - port: 5432
+          protocol: TCP
+        - port: 8000
+          protocol: TCP
+    # Allow traffic from Prometheus (metrics)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: 9187
+          protocol: TCP

--- a/apps/hearthly-api/deploy/chart/templates/networkpolicy.yaml
+++ b/apps/hearthly-api/deploy/chart/templates/networkpolicy.yaml
@@ -1,0 +1,50 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    {{- include "hearthly-api.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "hearthly-api.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow traffic from Traefik ingress controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: traefik
+      ports:
+        - port: {{ .Values.service.port }}
+          protocol: TCP
+    # Allow traffic from Prometheus (metrics scraping)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: {{ .Values.service.port }}
+          protocol: TCP
+  egress:
+    # Allow traffic to hearthly-db (PostgreSQL)
+    - to:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: hearthly-db
+      ports:
+        - port: 5432
+          protocol: TCP
+    # Allow external HTTPS (Keycloak JWKS via auth.hearthly.dev, S3 backups)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - port: 443
+          protocol: TCP

--- a/apps/hearthly-api/deploy/chart/templates/networkpolicy.yaml
+++ b/apps/hearthly-api/deploy/chart/templates/networkpolicy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "hearthly-api.labels" . | nindent 4 }}
 spec:
+  # Also covers backup CronJob pods (hearthly-api-db-backup) which share these labels
   podSelector:
     matchLabels:
       {{- include "hearthly-api.selectorLabels" . | nindent 6 }}

--- a/apps/hearthly-app/deploy/chart/templates/networkpolicy.yaml
+++ b/apps/hearthly-app/deploy/chart/templates/networkpolicy.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    {{- include "hearthly-app.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "hearthly-app.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow traffic from Traefik ingress controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: traefik
+      ports:
+        - port: {{ .Values.service.port }}
+          protocol: TCP
+    # Allow traffic from Prometheus (metrics scraping)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: {{ .Values.service.port }}
+          protocol: TCP

--- a/infrastructure/cluster-services/argocd/applications/network-policies.yaml
+++ b/infrastructure/cluster-services/argocd/applications/network-policies.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: network-policies
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/rudingma/hearthly.git
+    targetRevision: main
+    path: infrastructure/network-policies
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/infrastructure/cluster-services/keycloak/templates/networkpolicy-db.yaml
+++ b/infrastructure/cluster-services/keycloak/templates/networkpolicy-db.yaml
@@ -1,0 +1,39 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: keycloak-db
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: keycloak-db
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow traffic from Keycloak (PostgreSQL queries)
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "keycloak.selectorLabels" . | nindent 14 }}
+      ports:
+        - port: 5432
+          protocol: TCP
+    # Allow traffic from CNPG operator (management + status)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cnpg-system
+      ports:
+        - port: 5432
+          protocol: TCP
+        - port: 8000
+          protocol: TCP
+    # Allow traffic from Prometheus (metrics)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: 9187
+          protocol: TCP

--- a/infrastructure/cluster-services/keycloak/templates/networkpolicy.yaml
+++ b/infrastructure/cluster-services/keycloak/templates/networkpolicy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
 spec:
+  # Also covers backup CronJob pods (keycloak-db-backup) which share these labels
   podSelector:
     matchLabels:
       {{- include "keycloak.selectorLabels" . | nindent 6 }}

--- a/infrastructure/cluster-services/keycloak/templates/networkpolicy.yaml
+++ b/infrastructure/cluster-services/keycloak/templates/networkpolicy.yaml
@@ -20,6 +20,14 @@ spec:
       ports:
         - port: http
           protocol: TCP
+    # Allow traffic from Prometheus (metrics on management port)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: management
+          protocol: TCP
   egress:
     # Allow DNS resolution
     - to:

--- a/infrastructure/network-policies/Chart.yaml
+++ b/infrastructure/network-policies/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: network-policies
+version: 0.1.0
+description: Baseline and infrastructure NetworkPolicies for Hearthly cluster

--- a/infrastructure/network-policies/templates/_helpers.tpl
+++ b/infrastructure/network-policies/templates/_helpers.tpl
@@ -1,0 +1,4 @@
+{{- define "network-policies.labels" -}}
+app.kubernetes.io/name: network-policies
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/infrastructure/network-policies/templates/allow-dns.yaml
+++ b/infrastructure/network-policies/templates/allow-dns.yaml
@@ -1,0 +1,27 @@
+{{- range .Values.namespaces }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns
+  namespace: {{ . }}
+  labels:
+    {{- include "network-policies.labels" $ | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+{{- end }}

--- a/infrastructure/network-policies/templates/argocd.yaml
+++ b/infrastructure/network-policies/templates/argocd.yaml
@@ -1,0 +1,74 @@
+# ArgoCD: allow intra-namespace communication between components
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-argocd-intra-namespace
+  namespace: argocd
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+  egress:
+    - to:
+        - podSelector: {}
+---
+# ArgoCD server: allow ingress from Traefik
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-argocd-server-ingress
+  namespace: argocd
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-server
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: traefik
+      ports:
+        - port: 8080
+          protocol: TCP
+---
+# ArgoCD: allow egress to K8s API server and external HTTPS (GitHub)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-argocd-egress
+  namespace: argocd
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    # K8s API server
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.apiServer.clusterIP }}/32
+      ports:
+        - port: 443
+          protocol: TCP
+    # External HTTPS (GitHub repo access)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - port: 443
+          protocol: TCP

--- a/infrastructure/network-policies/templates/cnpg-system.yaml
+++ b/infrastructure/network-policies/templates/cnpg-system.yaml
@@ -1,0 +1,88 @@
+# CNPG: allow intra-namespace communication
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cnpg-intra-namespace
+  namespace: cnpg-system
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+  egress:
+    - to:
+        - podSelector: {}
+---
+# CNPG operator: allow egress to database namespaces (5432 + 8000)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cnpg-db-egress
+  namespace: cnpg-system
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: hearthly
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: keycloak
+      ports:
+        - port: 5432
+          protocol: TCP
+        - port: 8000
+          protocol: TCP
+---
+# CNPG operator: allow egress to K8s API server
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cnpg-api-egress
+  namespace: cnpg-system
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.apiServer.clusterIP }}/32
+      ports:
+        - port: 443
+          protocol: TCP
+---
+# CNPG operator: allow ingress from Prometheus (metrics on 8080)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cnpg-prometheus-ingress
+  namespace: cnpg-system
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cloudnative-pg
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: 8080
+          protocol: TCP

--- a/infrastructure/network-policies/templates/default-deny.yaml
+++ b/infrastructure/network-policies/templates/default-deny.yaml
@@ -1,0 +1,15 @@
+{{- range .Values.namespaces }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: {{ . }}
+  labels:
+    {{- include "network-policies.labels" $ | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+{{- end }}

--- a/infrastructure/network-policies/templates/infisical.yaml
+++ b/infrastructure/network-policies/templates/infisical.yaml
@@ -1,0 +1,74 @@
+# Infisical: allow intra-namespace communication
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-infisical-intra-namespace
+  namespace: infisical
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+  egress:
+    - to:
+        - podSelector: {}
+---
+# Infisical app: allow ingress from Traefik
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-infisical-traefik-ingress
+  namespace: infisical
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: infisical-standalone
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: traefik
+      ports:
+        - port: 8080
+          protocol: TCP
+---
+# Infisical: allow egress to K8s API server and external HTTPS
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-infisical-egress
+  namespace: infisical
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    # K8s API server
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.apiServer.clusterIP }}/32
+      ports:
+        - port: 443
+          protocol: TCP
+    # External HTTPS
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - port: 443
+          protocol: TCP

--- a/infrastructure/network-policies/templates/monitoring.yaml
+++ b/infrastructure/network-policies/templates/monitoring.yaml
@@ -1,0 +1,82 @@
+# Monitoring: allow intra-namespace communication
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-monitoring-intra-namespace
+  namespace: monitoring
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+  egress:
+    - to:
+        - podSelector: {}
+---
+# Grafana: allow ingress from Traefik
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-grafana-ingress
+  namespace: monitoring
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: traefik
+      ports:
+        - port: 3000
+          protocol: TCP
+---
+# Prometheus: allow egress to all namespaces for metrics scraping
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-prometheus-scraping
+  namespace: monitoring
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector: {}
+---
+# Prometheus operator: allow egress to K8s API server
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-operator-api-egress
+  namespace: monitoring
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kube-prometheus-stack-operator
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.apiServer.clusterIP }}/32
+      ports:
+        - port: 443
+          protocol: TCP

--- a/infrastructure/network-policies/values.yaml
+++ b/infrastructure/network-policies/values.yaml
@@ -1,0 +1,10 @@
+namespaces:
+  - hearthly
+  - keycloak
+  - argocd
+  - monitoring
+  - cnpg-system
+  - infisical
+
+apiServer:
+  clusterIP: 10.43.0.1


### PR DESCRIPTION
## Summary

- Default-deny both ingress and egress for 6 namespaces per NSA/CISA and CIS benchmarks
- Allow-DNS baseline scoped to kube-system/kube-dns for all namespaces
- Per-workload allow rules for legitimate traffic only
- Centralized Helm chart for baseline + infra namespace policies, synced by new ArgoCD Application
- Skips kube-system and traefik (risk of breaking CNI/ingress)

## Namespaces Covered

`hearthly`, `keycloak`, `argocd`, `monitoring`, `cnpg-system`, `infisical`

## Policies (31 total)

| Chart | Policies | What |
|---|---|---|
| Centralized (network-policies) | 26 | Default-deny (12) + allow-dns (6) + infra allow rules (8) |
| hearthly-app | 1 | Ingress from Traefik + Prometheus |
| hearthly-api | 2 | API ingress/egress + DB ingress |
| keycloak | 2 | Updated Keycloak + new keycloak-db |

## Test Plan

- [x] All 4 Helm charts render correctly (31 policies total)
- [x] `kubectl apply --dry-run=client` passes for all charts
- [x] Pod selectors verified against live cluster labels
- [x] Namespace labels verified (`kubernetes.io/metadata.name`)
- [x] Spec reviewed by Opus agent — 100% traffic matrix coverage
- [ ] Post-deploy: DNS resolution, DB connectivity, external HTTPS, Traefik ingress
- [ ] Post-deploy: negative test (hearthly-app cannot reach DB)

Closes #28