### PR TITLE
fix(infra): disable automountServiceAccountToken on app pods

### DIFF
--- a/apps/hearthly-api/deploy/chart/templates/cronjob-db-backup.yaml
+++ b/apps/hearthly-api/deploy/chart/templates/cronjob-db-backup.yaml
@@ -20,6 +20,7 @@ spec:
             {{- include "hearthly-api.selectorLabels" . | nindent 12 }}
             app.kubernetes.io/component: db-backup
         spec:
+          automountServiceAccountToken: false
           securityContext:
             runAsNonRoot: true
             seccompProfile:

--- a/apps/hearthly-api/deploy/chart/templates/deployment.yaml
+++ b/apps/hearthly-api/deploy/chart/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         {{- include "hearthly-api.selectorLabels" . | nindent 8 }}
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 100

--- a/apps/hearthly-app/deploy/chart/templates/deployment.yaml
+++ b/apps/hearthly-app/deploy/chart/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         {{- include "hearthly-app.selectorLabels" . | nindent 8 }}
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 101

--- a/infrastructure/cluster-services/keycloak/templates/cronjob-db-backup.yaml
+++ b/infrastructure/cluster-services/keycloak/templates/cronjob-db-backup.yaml
@@ -20,6 +20,7 @@ spec:
             {{- include "keycloak.selectorLabels" . | nindent 12 }}
             app.kubernetes.io/component: db-backup
         spec:
+          automountServiceAccountToken: false
           securityContext:
             runAsNonRoot: true
             seccompProfile:

--- a/infrastructure/cluster-services/keycloak/templates/deployment.yaml
+++ b/infrastructure/cluster-services/keycloak/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         {{- include "keycloak.selectorLabels" . | nindent 8 }}
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsUser: 1000
         runAsGroup: 0


### PR DESCRIPTION
## Summary

- Add `automountServiceAccountToken: false` to pod specs for hearthly-api, hearthly-app, keycloak deployments and both DB backup CronJobs
- None of these pods talk to the Kubernetes API — the projected SA token is unnecessary attack surface

Closes #29

## Context

RBAC audit (#29) found this as the only concrete finding. All `default` ServiceAccounts have minimal permissions (discovery only), but mounting the token at all is unnecessary.

## Test plan

- [x] `helm template` renders cleanly for all 3 charts
- [ ] Verify pods restart successfully after ArgoCD sync
- [ ] Confirm `/var/run/secrets/kubernetes.io/serviceaccount` is no longer mounted