### PR TITLE
chore(infra): commit Chart.lock for infisical and monitoring

### DIFF
--- a/infrastructure/cluster-services/infisical/Chart.lock
+++ b/infrastructure/cluster-services/infisical/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: infisical-standalone
+  repository: https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/
+  version: 1.7.5
+- name: secrets-operator
+  repository: https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/
+  version: 0.10.29
+digest: sha256:a41a2005db1aa86e99d3534bdca827ca9baa8ce1f28ab0f84a6089cd7835c385
+generated: "2026-04-11T12:45:44.633851+02:00"

--- a/infrastructure/cluster-services/monitoring/Chart.lock
+++ b/infrastructure/cluster-services/monitoring/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: kube-prometheus-stack
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 82.16.0
+digest: sha256:7111ebf88a570dd61a62928ec666f7ec6ef1b2c2e52ec5386307418d858d52b5
+generated: "2026-04-11T12:46:07.00939842+02:00"


### PR DESCRIPTION
## Summary

- Run `helm dependency build` for infisical and monitoring umbrella charts
- Commit the resulting `Chart.lock` files to pin exact dependency versions

Closes #38

## Context

Keycloak is a standalone chart (no deps), so no Chart.lock needed there. The `charts/` directories (downloaded archives) are already gitignored.

## Pinned versions

- **infisical:** infisical-standalone 1.7.5, secrets-operator 0.10.29
- **monitoring:** kube-prometheus-stack 82.16.0

## Test plan

- [x] `helm dependency build` succeeds for both charts
- [x] `charts/` dirs are gitignored (only Chart.lock tracked)
- [ ] ArgoCD sync still works after merge