### PR TITLE
feat(infra): manage hearthly-api database via ArgoCD

### DIFF
--- a/infrastructure/cluster-services/argocd/applications/hearthly-db.yaml
+++ b/infrastructure/cluster-services/argocd/applications/hearthly-db.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hearthly-db
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/rudingma/hearthly.git
+    targetRevision: main
+    path: apps/hearthly-api/infra
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hearthly
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true


### PR DESCRIPTION
## Summary

- Add ArgoCD Application `hearthly-db` pointing to `apps/hearthly-api/infra/`
- Mirrors the existing `keycloak-db` pattern: `prune: false`, `selfHeal: true`, `ServerSideApply=true`
- Live CNPG Cluster state matches the git manifest (verified: `generation: 1`, never modified since initial `kubectl apply`)

Closes #36

## Test plan

- [ ] ArgoCD creates `hearthly-db` Application and syncs successfully
- [ ] Application shows `Synced` + `Healthy` status
- [ ] Database pod is unaffected (no restart, no data loss)
- [ ] All health endpoints still return expected status codes