### PR TITLE
fix(monitoring): enable admission webhooks via cert-manager (#79)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,9 +135,9 @@ Two independent alerting paths push notifications to phone via public ntfy.sh:
 - **Custom PrometheusRules:** `TLSCertExpiringSoon` (< 14 days, warning), `BackupJobFailed` (critical), `HearthlyBackupMissing` / `KeycloakBackupMissing` (> 25h, warning), `HearthlyBackupNeverRan` / `KeycloakBackupNeverRan` (1h grace).
 - **ServiceMonitor:** `cert-manager` in monitoring namespace, scrapes port `tcp-prometheus-servicemonitor` (9402).
 - **NetworkPolicy:** `allow-alertmanager-ntfy-egress` — Alertmanager pods → external HTTPS (443) for ntfy.sh.
-- **Admission webhooks:** Disabled. Deployment mode has a TLS cert SAN mismatch; hook mode blocks ArgoCD PreSync. Validate PrometheusRules locally via `helm template`.
+- **Admission webhooks:** Enabled via cert-manager (`certManager.enabled: true`). cert-manager issues the webhook TLS cert and auto-injects the CA bundle, bypassing both the patch-Job SAN mismatch and ArgoCD PreSync hook issues. `failurePolicy: Fail` rejects invalid PrometheusRules at apply time. On first sync, a brief window exists between webhook config creation and cert issuance; ArgoCD self-heal resolves any transient PrometheusRule apply failures automatically.
 - **CRD selectors:** `ruleSelectorNilUsesHelmValues: false` + `serviceMonitorSelectorNilUsesHelmValues: false` — Prometheus discovers all custom rules/monitors without requiring release labels.
-- **Verify:** `kubectl get prometheusrules -n monitoring` (rules), `kubectl get servicemonitor -n monitoring` (monitors), `kubectl logs -n monitoring -l app.kubernetes.io/name=alertmanager -c ntfy-proxy --tail=10` (sidecar logs)
+- **Verify:** `kubectl get prometheusrules -n monitoring` (rules), `kubectl get servicemonitor -n monitoring` (monitors), `kubectl logs -n monitoring -l app.kubernetes.io/name=alertmanager -c ntfy-proxy --tail=10` (sidecar logs), `kubectl get validatingwebhookconfigurations monitoring-kube-prometheus-admission` (webhook), `kubectl get certificate -n monitoring` (webhook cert)
 
 ## Build & Run Commands
 
@@ -282,7 +282,7 @@ app/
 
 ## NetworkPolicies
 
-Default-deny both ingress and egress per namespace (NSA/CISA + CIS compliant). 31 policies across 6 namespaces.
+Default-deny both ingress and egress per namespace (NSA/CISA + CIS compliant). 35 policies across 6 namespaces.
 
 - **Covered:** `hearthly`, `keycloak`, `argocd`, `monitoring`, `cnpg-system`, `infisical`
 - **Skipped:** `kube-system` (risk of breaking CNI/DNS), `traefik` (ingress controller needs broad egress)

--- a/docs/project-summary.md
+++ b/docs/project-summary.md
@@ -84,9 +84,9 @@ kube-prometheus-stack ships 23 generic dashboards. Replaced with 1 custom "Heart
 - Saturation signals predict problems before outages (CPU throttling, memory-vs-limit)
 - Node rootfs disk monitoring (not just PVCs) — disk full triggers pod eviction
 
-### ArgoCD admission webhooks disabled
+### Admission webhooks via cert-manager
 
-kube-prometheus-stack's Helm hook annotations for admission webhook creation block ArgoCD sync permanently (PreSync hooks never complete). Webhooks only validate PrometheusRule CRDs — not needed until custom alerting rules are written (Observability milestone).
+kube-prometheus-stack admission webhooks validate PrometheusRule and AlertmanagerConfig CRDs at apply time (catches PromQL syntax errors). The default patch-Job approach was incompatible with ArgoCD (Helm hooks block PreSync). Resolved by using the chart's cert-manager integration (`certManager.enabled: true`) — cert-manager issues the webhook TLS cert and auto-injects the CA bundle, with no Helm hooks involved.
 
 ### ArgoCD controller memory (2Gi)
 

--- a/infrastructure/cluster-services/monitoring/values.yaml
+++ b/infrastructure/cluster-services/monitoring/values.yaml
@@ -247,12 +247,16 @@ kube-prometheus-stack:
 
   # --- Prometheus Operator ---
   prometheusOperator:
-    # Admission webhooks disabled — deployment mode has a TLS cert SAN
-    # mismatch (cert generated for operator service name, not webhook
-    # service name), and hook mode blocks ArgoCD PreSync. PrometheusRule
-    # validation is done locally via helm template instead.
+    # Admission webhooks validate PrometheusRule/AlertmanagerConfig CRDs
+    # at apply time (catches PromQL syntax errors before they reach Prometheus).
+    # cert-manager issues the webhook TLS cert and injects the CA bundle,
+    # avoiding both the patch-Job SAN mismatch and ArgoCD PreSync blocks.
     admissionWebhooks:
-      enabled: false
+      enabled: true
+      certManager:
+        enabled: true
+      patch:
+        enabled: false
     resources:
       requests:
         cpu: 50m

--- a/infrastructure/network-policies/templates/monitoring.yaml
+++ b/infrastructure/network-policies/templates/monitoring.yaml
@@ -113,6 +113,32 @@ spec:
         - port: 6443
           protocol: TCP
 ---
+# Prometheus operator: allow ingress from API server for admission webhook
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-operator-webhook-ingress
+  namespace: monitoring
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kube-prometheus-stack-operator
+  policyTypes:
+    - Ingress
+  ingress:
+    # API server → operator webhook (port 10250)
+    # ClusterIP before DNAT + node IP after DNAT
+    - from:
+        - ipBlock:
+            cidr: {{ .Values.apiServer.clusterIP }}/32
+        - ipBlock:
+            cidr: {{ .Values.apiServer.nodeIP }}/32
+      ports:
+        - port: 10250
+          protocol: TCP
+---
 # Alertmanager: allow egress to external HTTPS (ntfy.sh via sidecar)
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
## Summary

- Enable kube-prometheus-stack admission webhooks via cert-manager (`certManager.enabled: true`)
- Add NetworkPolicy allowing API server → operator pod on port 10250 for webhook calls
- Update CLAUDE.md and project-summary.md to reflect new state

## Why

Webhooks were disabled (#78) because patch-Job mode blocks ArgoCD PreSync and deployment mode had a TLS cert SAN mismatch. cert-manager integration bypasses both problems: it issues the cert with correct SANs and auto-injects the CA bundle via annotation — no Helm hooks involved. `failurePolicy: Fail` now rejects invalid PrometheusRules at apply time.

## Test plan

- [x] `helm template` renders monitoring chart with cert-manager Certificate, ValidatingWebhookConfiguration with `cert-manager.io/inject-ca-from`, no patch Jobs, `failurePolicy: Fail`
- [x] `helm template` renders network-policies chart with `allow-operator-webhook-ingress` policy
- [ ] After deploy: `kubectl get certificate -n monitoring monitoring-kube-prometheus-admission` shows Ready
- [ ] After deploy: `kubectl get validatingwebhookconfigurations monitoring-kube-prometheus-admission` exists with non-empty caBundle
- [ ] After deploy: existing PrometheusRules continue to apply cleanly (no false rejections)
- [ ] Health checks still 200/302 for hearthly.dev, api, auth, grafana, argocd

Closes #79