### PR TITLE
fix(monitoring): lower webhook TLS min version to 1.2 (#79)

### DIFF
--- a/infrastructure/cluster-services/monitoring/values.yaml
+++ b/infrastructure/cluster-services/monitoring/values.yaml
@@ -257,6 +257,11 @@ kube-prometheus-stack:
         enabled: true
       patch:
         enabled: false
+    # The operator's TLS server (port 10250) defaults to TLS 1.3 minimum,
+    # but the k3s API server's webhook client uses TLS 1.2 — handshake fails
+    # and webhook calls return 502 Bad Gateway. Lower to TLS 1.2 minimum.
+    tls:
+      tlsMinVersion: VersionTLS12
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
## Summary

After #81 enabled admission webhooks via cert-manager, all webhook calls fail with `502 Bad Gateway / proxy error`. Root cause: the operator's `--web.tls-min-version` defaults to TLS 1.3, but k3s's API server webhook client uses TLS 1.2.

Lower the minimum to TLS 1.2 — still secure, matches the k8s baseline, and unblocks webhook calls.

## Test plan

- [x] `helm template` shows `--web.tls-min-version=VersionTLS12`
- [ ] After deploy: PrometheusRules apply cleanly via the webhook
- [ ] After deploy: monitoring ArgoCD app reaches Synced/Healthy

Refs #79