### PR TITLE
fix(monitoring): move webhook to port 8443, lower TLS to 1.2 (#79)

### DIFF
--- a/infrastructure/cluster-services/monitoring/values.yaml
+++ b/infrastructure/cluster-services/monitoring/values.yaml
@@ -257,10 +257,10 @@ kube-prometheus-stack:
         enabled: true
       patch:
         enabled: false
-    # The operator's TLS server (port 10250) defaults to TLS 1.3 minimum,
-    # but the k3s API server's webhook client uses TLS 1.2 — handshake fails
-    # and webhook calls return 502 Bad Gateway. Lower to TLS 1.2 minimum.
+    # Default port (10250) collides with the kubelet port and isn't reachable
+    # by the k3s API server's webhook proxy. Use 8443 instead.
     tls:
+      internalPort: 8443
       tlsMinVersion: VersionTLS12
     resources:
       requests:

--- a/infrastructure/network-policies/templates/monitoring.yaml
+++ b/infrastructure/network-policies/templates/monitoring.yaml
@@ -128,7 +128,7 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # API server → operator webhook (port 10250)
+    # API server → operator webhook (port 8443)
     # ClusterIP before DNAT + node IP after DNAT
     - from:
         - ipBlock:
@@ -136,7 +136,7 @@ spec:
         - ipBlock:
             cidr: {{ .Values.apiServer.nodeIP }}/32
       ports:
-        - port: 10250
+        - port: 8443
           protocol: TCP
 ---
 # Alertmanager: allow egress to external HTTPS (ntfy.sh via sidecar)


### PR DESCRIPTION
## Summary

Follow-up to #82. Webhooks still fail with `502 Bad Gateway / proxy error from 127.0.0.1:6443 while dialing <pod-ip>:10250`. The root cause is port 10250 — same as the kubelet — which the k3s API server's webhook proxy can't reach cleanly. Moving to 8443 should resolve it.

## Test plan

- [x] `helm template` shows operator listening on 8443 and webhook NetworkPolicy on 8443
- [ ] After deploy: PrometheusRules apply through the webhook
- [ ] After deploy: monitoring app reaches Synced/Healthy

Refs #79