### PR TITLE
fix(network-policies): remove source restriction on webhook ingress (#79)

### DIFF
--- a/infrastructure/network-policies/templates/monitoring.yaml
+++ b/infrastructure/network-policies/templates/monitoring.yaml
@@ -128,14 +128,11 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # API server → operator webhook (port 8443)
-    # ClusterIP before DNAT + node IP after DNAT
-    - from:
-        - ipBlock:
-            cidr: {{ .Values.apiServer.clusterIP }}/32
-        - ipBlock:
-            cidr: {{ .Values.apiServer.nodeIP }}/32
-      ports:
+    # API server → operator webhook (port 8443).
+    # Source IP restriction omitted on purpose: the k3s API server's
+    # source IP for webhook calls is not a stable, target-able address
+    # (this matches the pattern used for cnpg's webhook ingress policy).
+    - ports:
         - port: 8443
           protocol: TCP
 ---


### PR DESCRIPTION
## Summary

The k3s API server's source IP for admission webhook calls is not a stable, target-able address. The previous `ipBlock` restriction (cluster IP + node IP) was wrong, causing all webhook calls to fail with `502 Bad Gateway`.

Match the working pattern from `allow-cnpg-webhook-ingress`: just allow the webhook port with no source restriction. Webhook security is enforced at the TLS layer via cert auth.

## Test plan

- [x] `helm template` renders without source restriction
- [ ] After deploy: webhook calls succeed, monitoring app reaches Synced/Healthy

Refs #79