### PR TITLE
fix(monitoring): resolve Grafana HTTPRoute OutOfSync drift (#80)

### DIFF
--- a/infrastructure/cluster-services/monitoring/values.yaml
+++ b/infrastructure/cluster-services/monitoring/values.yaml
@@ -6,6 +6,11 @@ kube-prometheus-stack:
 
   # --- Grafana ---
   grafana:
+    # ArgoCD renders Helm in its own namespace (argocd), so
+    # .Release.Namespace ≠ the destination namespace (monitoring).
+    # Without this override, the Grafana HTTPRoute renders with
+    # namespace: argocd, causing persistent OutOfSync drift.
+    namespaceOverride: monitoring
     ingress:
       enabled: false
     route:


### PR DESCRIPTION
## Summary

The Grafana HTTPRoute renders with `namespace: argocd` because the Grafana subchart uses `.Release.Namespace` which resolves to ArgoCD's own namespace during Helm rendering. For standard K8s resources, ArgoCD overrides the namespace during comparison, but for Gateway API CRDs (HTTPRoute) it doesn't — causing permanent OutOfSync drift.

Fix: set `grafana.namespaceOverride: monitoring` so the subchart renders the correct namespace.

## Test plan

- [x] `helm template` renders HTTPRoute with `namespace: monitoring`
- [ ] After deploy: monitoring ArgoCD app shows `Synced` (no more HTTPRoute drift)

Closes #80