### PR TITLE
fix(monitoring): add explicit group/kind to HTTPRoute parentRefs (#80)

### DIFF
--- a/infrastructure/cluster-services/monitoring/values.yaml
+++ b/infrastructure/cluster-services/monitoring/values.yaml
@@ -17,7 +17,9 @@ kube-prometheus-stack:
       main:
         enabled: true
         parentRefs:
-          - name: traefik-gateway
+          - group: gateway.networking.k8s.io
+            kind: Gateway
+            name: traefik-gateway
             namespace: traefik
             sectionName: websecure-grafana
         hostnames:


### PR DESCRIPTION
## Summary

Follow-up to #87. The namespace fix alone wasn't enough — the API server fills in `group: gateway.networking.k8s.io` and `kind: Gateway` as defaults on HTTPRoute `parentRefs`. ServerSideApply sees these extra fields as drift.

Add the defaults explicitly so the rendered manifest matches the live object.

## Test plan

- [x] `helm template` renders parentRefs with explicit group/kind
- [ ] After deploy: HTTPRoute shows `Synced` (no more OutOfSync)

Refs #80