### PR TITLE
feat(monitoring): add control plane OOM kill alerts and dashboard panels (#21)

### DIFF
--- a/infrastructure/cluster-services/monitoring/dashboards/hearthly-overview.json
+++ b/infrastructure/cluster-services/monitoring/dashboards/hearthly-overview.json
@@ -439,6 +439,143 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent",
+          "max": 100
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 18,
+        "y": 1
+      },
+      "id": 33,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * on(instance) group_left(nodename) node_uname_info{nodename=~\"k3s-control-plane.*\"} * 100",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "CP Memory %",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "noValue": "No OOM",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 21,
+        "y": 1
+      },
+      "id": 34,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "increase(node_vmstat_oom_kill[1h]) and on(instance) node_uname_info{nodename=~\"k3s-control-plane.*\"} or vector(0)",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "CP OOM (1h)",
+      "type": "stat"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,

--- a/infrastructure/cluster-services/monitoring/templates/prometheusrule-control-plane.yaml
+++ b/infrastructure/cluster-services/monitoring/templates/prometheusrule-control-plane.yaml
@@ -1,0 +1,42 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: control-plane-health
+  namespace: {{ .Release.Namespace }}
+spec:
+  groups:
+    - name: control-plane
+      rules:
+        - alert: ControlPlaneOOMKill
+          expr: >-
+            increase(node_vmstat_oom_kill[1h]) > 0
+            and on(instance)
+            node_uname_info{nodename=~"k3s-control-plane.*"}
+          labels:
+            severity: critical
+          annotations:
+            summary: >-
+              OOM kill detected on control plane node
+              {{ "{{" }} $labels.nodename {{ "}}" }}
+            description: >-
+              The kernel OOM killer was invoked on the control plane node
+              in the last hour. This may indicate the node needs more
+              memory (upgrade from CAX11 to CAX21).
+
+        - alert: ControlPlaneHighMemory
+          expr: >-
+            (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) > 0.9
+            and on(instance)
+            node_uname_info{nodename=~"k3s-control-plane.*"}
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: >-
+              Control plane memory usage above 90%
+              ({{ "{{" }} $value | humanizePercentage {{ "}}" }})
+            description: >-
+              Memory usage on control plane node
+              {{ "{{" }} $labels.nodename {{ "}}" }} has been above 90%
+              for 10 minutes. Sustained pressure increases OOM kill risk.
+              Consider upgrading to a larger node (CAX21).


### PR DESCRIPTION
## Summary

- Add PrometheusRule `control-plane-health` with two alerts:
  - `ControlPlaneOOMKill` (critical) — kernel OOM killer invoked on CP node
  - `ControlPlaneHighMemory` (warning) — CP memory usage > 90% for 10 min
- Add two stat panels to the dashboard's Emergency Signals row:
  - CP Memory % (yellow > 80%, red > 90%)
  - CP OOM (1h) (red on any kill)
- Uses `node_uname_info{nodename=~"k3s-control-plane.*"}` to identify the CP node by name pattern (no hardcoded IPs)

## Test plan

- [x] `helm template` renders PrometheusRule cleanly
- [x] PromQL queries verified against live Prometheus (CP memory = 65%, OOM kills = 0)
- [ ] After deploy: `kubectl get prometheusrules -n monitoring control-plane-health` exists
- [ ] After deploy: dashboard shows two new CP panels in Emergency Signals row
- [ ] After deploy: no admission webhook rejection (validates the PromQL is correct)

Closes #21