### PR TITLE
fix(deploy): drop COPY scripts/ from API + App Dockerfiles (#96)

### DIFF
--- a/apps/hearthly-api/deploy/Dockerfile
+++ b/apps/hearthly-api/deploy/Dockerfile
@@ -13,7 +13,6 @@ COPY package.json bun.lock ./
 COPY apps/hearthly-api/package.json ./apps/hearthly-api/
 COPY apps/hearthly-api-e2e/package.json ./apps/hearthly-api-e2e/
 COPY apps/hearthly-app-e2e/package.json ./apps/hearthly-app-e2e/
-COPY scripts/ ./scripts/
 RUN bun install --frozen-lockfile
 
 # Copy workspace source

--- a/apps/hearthly-app/deploy/Dockerfile
+++ b/apps/hearthly-app/deploy/Dockerfile
@@ -13,7 +13,6 @@ COPY package.json bun.lock ./
 COPY apps/hearthly-api/package.json ./apps/hearthly-api/
 COPY apps/hearthly-api-e2e/package.json ./apps/hearthly-api-e2e/
 COPY apps/hearthly-app-e2e/package.json ./apps/hearthly-app-e2e/
-COPY scripts/ ./scripts/
 RUN bun install --frozen-lockfile
 
 # Copy workspace source


### PR DESCRIPTION
## Summary

Phase 5 of PR #101 (the Ionic migration) deleted `scripts/patch-ionic-esm.mjs` and the empty `scripts/` directory along with the `postinstall` entry in `package.json`. Both Dockerfiles still tried to `COPY scripts/` pre-install so `bun install` could run the now-removed postinstall hook. The deploy pipeline fails at build-stage with:

```
failed to compute cache key: ... "/scripts": not found
```

Fix: drop the `COPY scripts/ ./scripts/` line from `apps/hearthly-api/deploy/Dockerfile` and `apps/hearthly-app/deploy/Dockerfile`. Nothing else in either build pipeline references `scripts/`.

Missed in #101 because the Docker builds only run on push to main (not PR CI), so the breakage surfaced on deploy.

## Test plan

- [x] Grep: no other `scripts/` references in the Dockerfiles
- [ ] Deploy pipeline succeeds after merge
- [ ] https://hearthly.dev, https://api.hearthly.dev/health return 200 after ArgoCD syncs