### PR TITLE
fix(network-policies): grant CNPG instances egress to API server (#128)

### DIFF
--- a/apps/hearthly-api/deploy/chart/templates/networkpolicy-db.yaml
+++ b/apps/hearthly-api/deploy/chart/templates/networkpolicy-db.yaml
@@ -10,6 +10,37 @@ spec:
       cnpg.io/cluster: hearthly-db
   policyTypes:
     - Ingress
+    - Egress
+  egress:
+    # Allow DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow egress to the K8s API server. The CNPG instance manager watches its
+    # Cluster CR via the API server; without this it crash-loops on startup
+    # ("dial 10.43.0.1:443: connection refused" under default-deny) — root cause
+    # of the 2026-05 outage recovery block. kube-router evaluates egress AFTER
+    # kube-proxy DNAT, so both the ClusterIP (pre-DNAT) and the control-plane
+    # node IP (post-DNAT) are required. See issue #128 and infrastructure/CLAUDE.md.
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.apiServer.clusterIP }}/32
+        - ipBlock:
+            cidr: {{ .Values.apiServer.nodeIP }}/32
+      ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
   ingress:
     # Allow traffic from hearthly-api (PostgreSQL queries)
     - from:

--- a/apps/hearthly-api/deploy/chart/values.yaml
+++ b/apps/hearthly-api/deploy/chart/values.yaml
@@ -8,6 +8,15 @@ image:
 service:
   port: 3000
 
+# K8s API server addresses for the hearthly-db CNPG instance egress policy.
+# kube-router evaluates egress AFTER kube-proxy DNAT, so both the ClusterIP
+# (pre-DNAT) and the control-plane node IP (post-DNAT) are required. Keep in
+# sync with infrastructure/network-policies/values.yaml. Update nodeIP if the
+# control-plane node is replaced.
+apiServer:
+  clusterIP: 10.43.0.1
+  nodeIP: 10.255.0.101
+
 route:
   enabled: true
   host: api.hearthly.dev

--- a/infrastructure/cluster-services/keycloak/templates/networkpolicy-db.yaml
+++ b/infrastructure/cluster-services/keycloak/templates/networkpolicy-db.yaml
@@ -10,6 +10,37 @@ spec:
       cnpg.io/cluster: keycloak-db
   policyTypes:
     - Ingress
+    - Egress
+  egress:
+    # Allow DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow egress to the K8s API server. The CNPG instance manager watches its
+    # Cluster CR via the API server; without this it crash-loops on startup
+    # ("dial 10.43.0.1:443: connection refused" under default-deny) — root cause
+    # of the 2026-05 outage recovery block. kube-router evaluates egress AFTER
+    # kube-proxy DNAT, so both the ClusterIP (pre-DNAT) and the control-plane
+    # node IP (post-DNAT) are required. See issue #128 and infrastructure/CLAUDE.md.
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.apiServer.clusterIP }}/32
+        - ipBlock:
+            cidr: {{ .Values.apiServer.nodeIP }}/32
+      ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
   ingress:
     # Allow traffic from Keycloak (PostgreSQL queries)
     - from:

--- a/infrastructure/cluster-services/keycloak/values.yaml
+++ b/infrastructure/cluster-services/keycloak/values.yaml
@@ -12,6 +12,15 @@ service:
   httpPort: 8080
   managementPort: 9000
 
+# K8s API server addresses for the keycloak-db CNPG instance egress policy.
+# kube-router evaluates egress AFTER kube-proxy DNAT, so both the ClusterIP
+# (pre-DNAT) and the control-plane node IP (post-DNAT) are required. Keep in
+# sync with infrastructure/network-policies/values.yaml. Update nodeIP if the
+# control-plane node is replaced.
+apiServer:
+  clusterIP: 10.43.0.1
+  nodeIP: 10.255.0.101
+
 route:
   enabled: true
   host: auth.hearthly.dev


### PR DESCRIPTION
## What

Adds `Egress` to the `hearthly-db` and `keycloak-db` CNPG instance NetworkPolicies: DNS + the K8s API server (ClusterIP `10.43.0.1:443` pre-DNAT and control-plane node IP `10.255.0.101:6443` post-DNAT, per the kube-router-evaluates-egress-after-DNAT quirk documented in `infrastructure/CLAUDE.md`).

## Why

During the 2026-05 outage recovery (postmortem #127), the CNPG Postgres **instance** pods crash-looped on `dial 10.43.0.1:443: connect: connection refused`. They had **no** API-server egress allow, and `default-deny-all` blocked them. The CNPG instance manager watches its `Cluster` CR via the API server, so this egress is required for the DB pods to start. The chart granted this egress to cnpg-system/argocd/monitoring/infisical but never to the `hearthly`/`keycloak` namespaces where instances actually run.

A manual `allow-cnpg-instance-api-egress` policy was applied live to restore production. This PR codifies the fix so it survives sync/rebuild.

## After merge

Once ArgoCD syncs the updated `hearthly-db`/`keycloak-db` policies (now with Egress), delete the redundant manual policies:
```
kubectl -n hearthly delete networkpolicy allow-cnpg-instance-api-egress
kubectl -n keycloak delete networkpolicy allow-cnpg-instance-api-egress
```
Then confirm a DB pod restart still starts cleanly.

## Gates
- `helm template` renders both charts cleanly with the egress rules.
- `bun run format:check` passes.

Closes #128. Refs #127.