### PR TITLE
fix(infra): restore Prometheus service discovery + node disk alerts (#131)

### DIFF
--- a/infrastructure/CLAUDE.md
+++ b/infrastructure/CLAUDE.md
@@ -76,7 +76,8 @@ Two independent alerting paths push notifications via ntfy.sh:
 - **ntfy topic:** Infisical (`NTFY_TOPIC`), intentionally decoupled between cluster and GitHub Actions.
 - **Custom rules:** See `cluster-services/monitoring/templates/prometheusrule-*.yaml`
 - **Admission webhooks:** cert-manager issues webhook TLS cert. k3s quirks: webhook port must be 8443 (not 10250), NetworkPolicy must allow ingress from any source on that port.
-- **CRD selectors:** `ruleSelectorNilUsesHelmValues: false` + `serviceMonitorSelectorNilUsesHelmValues: false`
+- **CRD selectors:** `ruleSelectorNilUsesHelmValues: false` + `serviceMonitorSelectorNilUsesHelmValues: false` + `podMonitorSelectorNilUsesHelmValues: false` (so the kured PodMonitor in kube-system is discovered without a release label)
+- **Node disk alerts:** `prometheusrule-node-disk.yaml` (root-disk fill, DiskPressure, kured health) + `podmonitor-kured.yaml` scrape kured's `:8080/metrics`. kured-derived alerts (`KuredDown`, `NodeRebootDebt`) only fire once kured is un-paused (architecture Phase A.4); disk alerts work immediately.
 - **Grafana gotchas:** Uses `namespaceOverride: monitoring` (ArgoCD renders in argocd namespace, causes drift without this). Uses `Recreate` strategy (hcloud-volumes are ReadWriteOnce — RollingUpdate fails).
 
 ## NetworkPolicies

--- a/infrastructure/cluster-services/monitoring/templates/podmonitor-kured.yaml
+++ b/infrastructure/cluster-services/monitoring/templates/podmonitor-kured.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: kured
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: kured
+spec:
+  # kured runs as a raw DaemonSet in kube-system (installed by kube-hetzner),
+  # not by this chart, so we select it cross-namespace by its pod label.
+  namespaceSelector:
+    matchNames:
+      - kube-system
+  selector:
+    matchLabels:
+      name: kured
+  podMetricsEndpoints:
+    # kured declares a named container port `metrics` on :8080.
+    - port: metrics
+      interval: 30s

--- a/infrastructure/cluster-services/monitoring/templates/prometheusrule-node-disk.yaml
+++ b/infrastructure/cluster-services/monitoring/templates/prometheusrule-node-disk.yaml
@@ -1,0 +1,78 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: node-disk-and-reboot
+  namespace: {{ .Release.Namespace }}
+spec:
+  groups:
+    - name: node-disk
+      rules:
+        # --- Root-disk fill (the 2026-05 outage cause) -------------------
+        # MicroOS accumulates OS-update snapshots; if kured cannot drain a
+        # node they are never reaped and the 40 GB root fills until kubelet
+        # mass-evicts pods. Alert well before eviction (~8-15% free).
+        - alert: NodeRootDiskFillingFast
+          expr: >-
+            (node_filesystem_avail_bytes{mountpoint="/",fstype!="tmpfs"} /
+             node_filesystem_size_bytes{mountpoint="/",fstype!="tmpfs"}) < 0.30
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: >-
+              Node {{ "{{" }} $labels.instance {{ "}}" }} root filesystem under 30% free
+            description: >-
+              Investigate before kubelet eviction (~8-15% free). Likely cause:
+              snapper snapshot accumulation. Runbook:
+              docs/superpowers/plans/2026-05-28-incident-recovery-runbook.md
+        - alert: NodeRootDiskCritical
+          expr: >-
+            (node_filesystem_avail_bytes{mountpoint="/",fstype!="tmpfs"} /
+             node_filesystem_size_bytes{mountpoint="/",fstype!="tmpfs"}) < 0.15
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: >-
+              Node {{ "{{" }} $labels.instance {{ "}}" }} root filesystem under 15% free — eviction imminent
+            description: >-
+              Run infrastructure/cluster/scripts/snapper-tune.sh on the node or
+              expand the disk now.
+        - alert: NodeDiskPressure
+          expr: kube_node_status_condition{condition="DiskPressure",status="true"} == 1
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: >-
+              Node {{ "{{" }} $labels.node {{ "}}" }} DiskPressure=True
+            description: >-
+              Kubelet is evicting pods. See recovery runbook Phase 1.
+        # --- kured health (only meaningful once kured is un-paused, A.4) --
+        # While kured is parked (DaemonSet desired=0 during the post-outage
+        # freeze) desired==ready==0, so KuredDown does NOT fire. After A.4
+        # un-pauses kured, desired>0 and this catches a degraded reboot loop.
+        - alert: KuredDown
+          expr: >-
+            kube_daemonset_status_number_ready{daemonset="kured",namespace="kube-system"}
+              < kube_daemonset_status_desired_number_scheduled{daemonset="kured",namespace="kube-system"}
+          for: 30m
+          labels:
+            severity: critical
+          annotations:
+            summary: >-
+              kured DaemonSet degraded — automatic reboots are not happening
+            description: >-
+              Without kured, MicroOS update snapshots accumulate. This preceded
+              the 2026-05 outage.
+        - alert: NodeRebootDebt
+          expr: kured_reboot_required == 1
+          for: 24h
+          labels:
+            severity: warning
+          annotations:
+            summary: >-
+              Node {{ "{{" }} $labels.instance {{ "}}" }} has needed a reboot for >24h
+            description: >-
+              kured flags reboot-required but the node has not rebooted. Verify
+              drains can succeed (CNPG HA, no AllowedDisruptions=0 PDBs).

--- a/infrastructure/cluster-services/monitoring/values.yaml
+++ b/infrastructure/cluster-services/monitoring/values.yaml
@@ -88,11 +88,13 @@ kube-prometheus-stack:
               requests:
                 storage: 10Gi
 
-      # Discover ALL PrometheusRules and ServiceMonitors, not just those
-      # with a release label matching this Helm chart. Required for custom
-      # rules in wrapper chart templates and cross-namespace ServiceMonitors.
+      # Discover ALL PrometheusRules, ServiceMonitors and PodMonitors, not
+      # just those with a release label matching this Helm chart. Required for
+      # custom rules in wrapper chart templates, cross-namespace ServiceMonitors,
+      # and the kured PodMonitor (kured is a raw DaemonSet in kube-system).
       ruleSelectorNilUsesHelmValues: false
       serviceMonitorSelectorNilUsesHelmValues: false
+      podMonitorSelectorNilUsesHelmValues: false
 
   # --- Alertmanager → ntfy.sh via alertmanager-ntfy sidecar ---
   alertmanager:

--- a/infrastructure/cluster/scripts/snapper-tune.sh
+++ b/infrastructure/cluster/scripts/snapper-tune.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Tighten MicroOS snapper retention and reclaim btrfs allocation headroom.
+# Run as root on each k3s node. Idempotent — safe to re-run.
+#
+# Why: kube-hetzner/MicroOS ships NUMBER_LIMIT=50 plus generous timeline
+# limits, so daily OS-update snapshots pile up. When kured cannot drain a node
+# (the 2026-05 outage), they are never reaped and fill the 40 GB root disk.
+# We cap retention low and reclaim empty/sparse data chunks back to
+# *unallocated* so btrfs can always grow its metadata block group — this is
+# what prevents the metadata-ENOSPC deadlock that locked nsd's snapshots.
+#
+# MicroOS mounts the running root subvolume read-only, so the btrfs write
+# ioctls (balance, quota rescan) must target a writable mount on the SAME
+# filesystem: /var is a separate rw subvolume on /dev/sda2. Balancing the
+# read-only '/' mount fails with EROFS (the bug seen in the recovery runbook).
+#
+# See issue #131 (stopgap) and docs/superpowers/plans/2026-05-28-cluster-architecture.md (Task C.3).
+set -euo pipefail
+
+echo "== before =="
+echo -n "snapshots: "; snapper -c root list | grep -c '^[0-9]' || true
+df -h / | tail -1
+
+snapper -c root set-config \
+  NUMBER_LIMIT=15 NUMBER_LIMIT_IMPORTANT=5 \
+  TIMELINE_LIMIT_HOURLY=4 TIMELINE_LIMIT_DAILY=7 \
+  TIMELINE_LIMIT_WEEKLY=2 TIMELINE_LIMIT_MONTHLY=1 \
+  TIMELINE_LIMIT_QUARTERLY=0 TIMELINE_LIMIT_YEARLY=0
+
+snapper -c root cleanup number
+snapper -c root cleanup timeline
+
+# Reclaim empty/sparse data chunks back to unallocated. Non-fatal: a node with
+# ample unallocated headroom needs no balancing. Target the writable /var mount.
+echo "== btrfs balance via /var (non-fatal) =="
+btrfs balance start -dusage=20 /var 2>&1 | tail -2 || echo "balance skipped/failed — non-fatal"
+
+# Repair qgroup accounting drift (snapper uses it for cleanup decisions).
+btrfs quota rescan -w /var 2>&1 | tail -1 || echo "quota rescan skipped — non-fatal"
+
+echo "== after =="
+echo -n "snapshots: "; snapper -c root list | grep -c '^[0-9]' || true
+df -h / | tail -1
+btrfs fi usage /var 2>/dev/null | grep -iE 'Device unallocated|Metadata,' || true

--- a/infrastructure/network-policies/templates/monitoring.yaml
+++ b/infrastructure/network-policies/templates/monitoring.yaml
@@ -56,8 +56,26 @@ spec:
   policyTypes:
     - Egress
   egress:
+    # Scrape targets (pod metrics endpoints) in every namespace.
     - to:
         - namespaceSelector: {}
+    # K8s API server (ClusterIP before DNAT + node IP after DNAT). Prometheus
+    # needs this for Kubernetes service discovery — without it SD returns zero
+    # endpoints and Prometheus scrapes NOTHING (0 active targets), silently
+    # blinding all in-cluster alerting. The namespaceSelector rule above does
+    # NOT cover it: kube-router evaluates egress post-DNAT, so the destination
+    # is the node IP (a non-pod address) which no namespaceSelector matches.
+    # Same root cause as the 2026-05 outage's CNPG egress gap. See issue #131.
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.apiServer.clusterIP }}/32
+        - ipBlock:
+            cidr: {{ .Values.apiServer.nodeIP }}/32
+      ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
 ---
 # Grafana: allow egress to K8s API server (sidecars watch ConfigMaps/Secrets)
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
## Summary

Part of the #131 post-outage hardening stopgap. While building the disk-pressure alert I discovered **in-cluster monitoring was blind**: Prometheus had 28 scrape jobs configured but **0 active targets** and a near-empty TSDB. An alert on a blind Prometheus is useless, so this PR fixes the root cause *and* adds the disk alerts.

### Root cause (same class as the 2026-05 outage)
`allow-prometheus-scraping` only allowed egress to `namespaceSelector: {}` (pods). Kubernetes service discovery talks to the **API server**, which kube-router sees **post-DNAT as the node IP** (`10.255.0.101:6443`) — a non-pod address no `namespaceSelector` matches, so default-deny blocked it. SD returned zero endpoints → Prometheus scraped nothing → **all in-cluster alerting was silent**. This is why the 16-day outage was only caught by the external GitHub healthcheck. Verified from inside the pod: both `10.43.0.1:443` and `10.255.0.101:6443` were BLOCKED.

The operator and grafana policies already carry the correct API-server `ipBlock` egress — `allow-prometheus-scraping` was simply missed.

## Changes
- **network-policies:** add API-server `ipBlock` egress (ClusterIP + node IP, 443/6443) to `allow-prometheus-scraping`, mirroring the operator/grafana policies.
- **monitoring:** new `node-disk-and-reboot` PrometheusRule — `NodeRootDiskFillingFast` (<30%), `NodeRootDiskCritical` (<15%), `NodeDiskPressure`, `KuredDown`, `NodeRebootDebt`. Plus a kured `PodMonitor` scraping `:8080/metrics`.
- **monitoring:** `podMonitorSelectorNilUsesHelmValues: false` so the kured PodMonitor (a raw DaemonSet in kube-system) is discovered without a release label — consistent with the existing rule/serviceMonitor selectors.
- **cluster/scripts/snapper-tune.sh:** durable retention script (`NUMBER_LIMIT=15`) + btrfs balance via the writable `/var` mount (sidesteps the EROFS-on-`ro`-`/` bug). **Already applied live** to all 4 nodes: freed 11 GB on nsd, restored 17–25 GiB unallocated cluster-wide, eliminating the metadata-ENOSPC deadlock precursor.

## Notes
- kured is intentionally **paused** (post-outage freeze), so `KuredDown`/`NodeRebootDebt` stay dormant (DaemonSet desired=0 → no false fire); they activate after Phase A.4 un-pauses kured. The **disk alerts work immediately**.
- Does **not** lift the freeze. That's Phase A (the proper CNPG-HA fix).

## Verification
- [x] `helm template` renders both charts; Prometheus templating escaped correctly.
- [x] `bun run format:check` passes.
- [ ] Post-merge: confirm Prometheus active targets > 0 and the `node-disk` rule group loads (will verify after ArgoCD sync).

Closes part of #131.