### PR TITLE
fix(infra): unblock kube-state-metrics + node-exporter/kubelet scraping (#131)

### DIFF
--- a/infrastructure/network-policies/templates/monitoring.yaml
+++ b/infrastructure/network-policies/templates/monitoring.yaml
@@ -76,6 +76,22 @@ spec:
           protocol: TCP
         - port: 6443
           protocol: TCP
+    # Node host-network scrape targets: node-exporter (:9100) and kubelet
+    # (:10250, incl. cadvisor/probes). These listen on the node IPs, which are
+    # host-network addresses no namespaceSelector matches — without this,
+    # node_filesystem_* / cadvisor / kubelet metrics are all missing and the
+    # node-disk alerts have no data. kube-router REJECTs the denied egress, so
+    # the symptom is "connection refused" on :9100 / :10250.
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.nodeSubnets.agents }}
+        - ipBlock:
+            cidr: {{ .Values.nodeSubnets.controlPlane }}
+      ports:
+        - port: 9100
+          protocol: TCP
+        - port: 10250
+          protocol: TCP
 ---
 # Grafana: allow egress to K8s API server (sidecars watch ConfigMaps/Secrets)
 apiVersion: networking.k8s.io/v1
@@ -119,6 +135,50 @@ spec:
   policyTypes:
     - Egress
   egress:
+    # K8s API server (ClusterIP before DNAT + node IP after DNAT)
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.apiServer.clusterIP }}/32
+        - ipBlock:
+            cidr: {{ .Values.apiServer.nodeIP }}/32
+      ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+---
+# kube-state-metrics: allow egress to K8s API server.
+# ksm opens a client to the API server at startup to list/watch objects; under
+# default-deny with no egress rule it crash-loops on
+# "dial 10.43.0.1:443: connect: connection refused", taking ALL kube_* metrics
+# (and every alert that depends on them) offline. Same DNAT caveat as above.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ksm-api-egress
+  namespace: monitoring
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  policyTypes:
+    - Egress
+  egress:
+    # DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
     # K8s API server (ClusterIP before DNAT + node IP after DNAT)
     - to:
         - ipBlock:

--- a/infrastructure/network-policies/values.yaml
+++ b/infrastructure/network-policies/values.yaml
@@ -13,3 +13,11 @@ apiServer:
   # compatibility with different CNI behaviors.
   clusterIP: 10.43.0.1
   nodeIP: 10.255.0.101
+
+# Node host-network subnets (kube-hetzner splits the default 10.0.0.0/8 network
+# into /16 subnets: agents take the first, the control plane the last). Prometheus
+# scrapes node-exporter (:9100) and kubelet (:10250) at these node IPs, which are
+# host-network targets that namespaceSelector cannot match — they need an ipBlock.
+nodeSubnets:
+  agents: 10.0.0.0/16
+  controlPlane: 10.255.0.0/16


### PR DESCRIPTION
## Summary

Follow-up to #132. That PR restored Prometheus **service discovery** (0 → 26 targets), which then revealed the node-level scrape targets were still down. This PR closes the last two NetworkPolicy gaps so monitoring is fully functional and the node-disk alerts have data.

### 1. kube-state-metrics — CrashLoopBackOff for 14 days (72 restarts)
ksm opens an API-server client at startup; under default-deny with **no egress policy** it died on `dial 10.43.0.1:443: connect: connection refused`. This took **all `kube_*` metrics** offline — and every alert depending on them (backup-failure, control-plane, and the `DiskPressure` signal). Add `allow-ksm-api-egress` (DNS + API server), mirroring the operator/grafana policies.

### 2. node-exporter (`:9100`) + kubelet (`:10250`)
These are **host-network targets at the node IPs**, which `namespaceSelector` can't match. kube-router REJECTs the denied egress (→ "connection refused"), so `node_filesystem_*` / cadvisor / kubelet metrics were all missing. Add a node-subnet egress rule to `allow-prometheus-scraping` covering the kube-hetzner agent (`10.0.0.0/16`) and control-plane (`10.255.0.0/16`) subnets on 9100/10250, parameterised via `nodeSubnets` in values.

## Verification
- [x] `helm template` renders; `bun run format:check` passes.
- [ ] Post-merge: ksm `Running` (no restarts), all 26 targets `up`, `node_filesystem_avail_bytes` + `kube_node_status_condition` present, `node-disk` rules healthy.

Part of #131.