### PR TITLE
feat(hearthly-db): HA (2 instances, async, anti-affinity) (#131)

### DIFF
--- a/apps/hearthly-api/infra/database.yaml
+++ b/apps/hearthly-api/infra/database.yaml
@@ -4,7 +4,14 @@ metadata:
   name: hearthly-db
   namespace: hearthly
 spec:
-  instances: 1
+  instances: 2
+
+  # Async replication: prioritise write availability over zero-RPO. We accept
+  # <= a few seconds of data loss on a hard primary failure rather than block
+  # writes when a standby is unhealthy. (Default minSync/maxSync = 0 is async;
+  # stated explicitly so the RPO decision is visible in Git.) See issue #131.
+  minSyncReplicas: 0
+  maxSyncReplicas: 0
 
   postgresql:
     parameters:
@@ -27,3 +34,11 @@ spec:
     initdb:
       database: hearthly
       owner: hearthly
+
+  # Keep the two instances on different nodes so a single node loss (or a kured
+  # drain) never takes the whole cluster down. required = hard constraint; with
+  # 3 schedulable workers there is always a second node for the standby.
+  affinity:
+    enablePodAntiAffinity: true
+    topologyKey: kubernetes.io/hostname
+    podAntiAffinityType: required


### PR DESCRIPTION
## Summary
Architecture plan **Task A.1** — the keystone of Phase A. Makes `hearthly-db` a 2-instance CNPG cluster with **required** node anti-affinity and explicit **async** replication.

Single-instance CNPG is what blocked kured drains during the 2026-05 outage (PDB `AllowedDisruptions=0` on the lone primary → snapshots piled up → disk cascade). With 2 instances on different nodes, CNPG does a **switchover before drain**, so kured can always drain a node — which is the prerequisite for un-pausing kured (Task A.4).

- `instances: 1 → 2`
- `enablePodAntiAffinity: true`, `podAntiAffinityType: required`, `topologyKey: kubernetes.io/hostname`
- `minSync/maxSync = 0` (async, RPO decision explicit in Git)

Capacity verified: nsd has ~2.9 GiB free for the standby (anti-affinity keeps it off lun where the primary lives).

## Verification (post-merge)
- [ ] 2 pods `1/1 Running` on **different** nodes
- [ ] `pg_stat_replication`: state=streaming, sync_state=async
- [ ] Drain rehearsals (run after A.2 so both DBs are HA): standby + primary switchover

Part of #131.