### PR TITLE
fix(network-policies): allow CNPG intra-cluster replication (#131)

### DIFF
--- a/apps/hearthly-api/deploy/chart/templates/networkpolicy-db.yaml
+++ b/apps/hearthly-api/deploy/chart/templates/networkpolicy-db.yaml
@@ -42,6 +42,18 @@ spec:
         - port: 6443
           protocol: TCP
   ingress:
+    # Allow intra-cluster replication: standby -> primary for pg_basebackup +
+    # streaming replication on 5432. CNPG instances all carry the label
+    # cnpg.io/cluster=hearthly-db. Without this the replica join hangs on
+    # "dial hearthly-db-rw:5432: connection refused" under default-deny —
+    # required once instances>1 (HA, architecture plan A.1). See issue #131.
+    - from:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: hearthly-db
+      ports:
+        - port: 5432
+          protocol: TCP
     # Allow traffic from hearthly-api (PostgreSQL queries)
     - from:
         - podSelector:

--- a/infrastructure/cluster-services/keycloak/templates/networkpolicy-db.yaml
+++ b/infrastructure/cluster-services/keycloak/templates/networkpolicy-db.yaml
@@ -42,6 +42,18 @@ spec:
         - port: 6443
           protocol: TCP
   ingress:
+    # Allow intra-cluster replication: standby -> primary for pg_basebackup +
+    # streaming replication on 5432. CNPG instances all carry the label
+    # cnpg.io/cluster=keycloak-db. Without this the replica join hangs on
+    # "dial keycloak-db-rw:5432: connection refused" under default-deny —
+    # required once instances>1 (HA, architecture plan A.2). See issue #131.
+    - from:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: keycloak-db
+      ports:
+        - port: 5432
+          protocol: TCP
     # Allow traffic from Keycloak (PostgreSQL queries)
     - from:
         - podSelector:


### PR DESCRIPTION
Going HA (A.1/A.2) exposed a NetworkPolicy gap — the DB ingress allowed hearthly-api/keycloak + cnpg-system + monitoring but not **pod-to-pod within the CNPG cluster**, so the standby join hangs on `dial <db>-rw:5432: connection refused` (pg_basebackup + streaming replication can't reach the primary). Adds an ingress rule for pods labelled `cnpg.io/cluster=<db>` on 5432, for both hearthly-db and keycloak-db. Unblocks A.1 (and A.2). Part of #131.