### PR TITLE
fix(infra): pin Traefik v3.6.15 to restore ingress (#131)

### DIFF
--- a/infrastructure/cluster/main.tf
+++ b/infrastructure/cluster/main.tf
@@ -80,6 +80,18 @@ module "kube-hetzner" {
   # Use stable k3s release channel
   initial_k3s_channel = "stable"
 
+  # Pin Traefik explicitly. A k3s/chart auto-upgrade silently bumped Traefik to
+  # v3.7.1 (which requires Gateway API v1.5.1 — TLSRoute is Standard at v1
+  # there), but the cluster's Gateway API CRDs are v1.4.0 (TLSRoute only
+  # experimental) → the kubernetesGateway provider could not sync the TLSRoute
+  # informer → zero HTTP routers → full ingress outage (2026-05-29). A
+  # load-bearing ingress must never float. Pinned to the v3.6.x chart line,
+  # which serves HTTPRoutes against the existing v1.4 CRDs. The forward move to
+  # v3.7.1 happens deliberately AFTER Gateway API v1.5.1 CRDs are owned in Git.
+  # See issue #131.
+  traefik_version   = "39.0.9"
+  traefik_image_tag = "v3.6.15"
+
   # Gateway API: enable Traefik's kubernetesGateway provider.
   # CRDs are bundled by the Traefik Helm chart; cert-manager Gateway API
   # support is enabled automatically by kube-hetzner when this flag is set.
@@ -90,6 +102,14 @@ module "kube-hetzner" {
   # v2.19+ defaults are v39-compatible (no globalArguments, correct
   # ports.web.http.redirections path), so merge-only is sufficient.
   traefik_merge_values = <<-EOT
+providers:
+  kubernetesGateway:
+    enabled: true
+    # Hearthly uses only HTTPRoute. experimentalChannel=false keeps TCPRoute out
+    # of the watch set. (NOTE: in Traefik v3.7 TLSRoute is Standard, so this flag
+    # no longer excludes TLSRoute — that is handled by owning the matching
+    # Gateway API CRDs, not by this flag.)
+    experimentalChannel: false
 gateway:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod


### PR DESCRIPTION
## Summary
**PR1** of the Codex-reviewed clean fix for the 2026-05-29 ingress outage.

**Root cause:** a k3s auto-upgrade silently bumped the *unpinned* Traefik to **v3.7.1**, which requires **Gateway API v1.5.1** (TLSRoute is *Standard* at `v1` there). The cluster's Gateway API CRDs are **v1.4.0** (TLSRoute only experimental, `v1alpha2/3`), so Traefik 3.7.1's `kubernetesGateway` provider couldn't sync its `v1.TLSRoute` informer → **zero HTTP routers → every host 404 → full ingress outage**. Everything else (DBs HA, kube-proxy, LB, certs, Gateway listeners) is healthy.

**This PR:** pin Traefik to the **v3.6.x chart line (chart 39.0.9 / image v3.6.15)** + `experimentalChannel: false`. v3.6 serves HTTPRoutes against the existing v1.4 CRDs → restores ingress, under deliberate version control. A load-bearing ingress must never float on k3s auto-upgrades.

## ⚠️ Reviewer note — Terraform plan gate
This changes `traefik_values`, which triggers `terraform_data.kustomization` to re-apply. That kustomization also carries kured + system-upgrade-controller, so the apply will reset their live state — effectively performing **Phase A.4** (un-pause kured + restore system-upgrade). That is safe/desired now (CNPG HA + both drain rehearsals passed). **The plan must show only the kustomization replace — no node/network/server changes. If it shows server/network drift, do not merge.**

## Clean end state (subsequent PRs)
- PR2: own Gateway API **v1.5.1 Standard** CRDs in Git (ArgoCD app).
- PR3: move Traefik forward to **v3.7.1** (chart 40.2.0) on matching CRDs.
- PR4: fail-loud ingress alerts (this outage was silent).

Part of #131.