### PR TITLE
fix(infra): pin Traefik + hccm/csi/kured compatibility set (#131)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -76,11 +76,27 @@ jobs:
       - name: Setup SSH key
         env:
           HCLOUD_SSH_PRIVATE_KEY: ${{ secrets.HCLOUD_SSH_PRIVATE_KEY }}
+          HCLOUD_SSH_PUBLIC_KEY: ${{ vars.HCLOUD_SSH_PUBLIC_KEY }}
         run: |
           mkdir -p ~/.ssh
           printenv HCLOUD_SSH_PRIVATE_KEY > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keygen -y -f ~/.ssh/id_ed25519 > ~/.ssh/id_ed25519.pub
+          # Write the CANONICAL public key (matches the key registered in Hetzner +
+          # tracked in TF state, comment included). Deriving it via `ssh-keygen -y`
+          # drops the comment and causes a spurious hcloud_ssh_key replacement in
+          # the plan (#131).
+          # Normalize: strip any stray CR/newlines the variable store may have
+          # added, then write exactly one trailing newline so the file matches
+          # the key in TF state byte-for-byte (else a trailing-newline mismatch
+          # still forces a spurious replacement).
+          printf '%s\n' "$(printf '%s' "$HCLOUD_SSH_PUBLIC_KEY" | tr -d '\r\n')" > ~/.ssh/id_ed25519.pub
+          # Guard: the private key secret must actually correspond to that public
+          # key. A byte-correct .pub with a wrong/rotated private key yields a clean
+          # plan but an apply that fails on the kustomization's SSH remote-exec.
+          if [ "$(ssh-keygen -y -f ~/.ssh/id_ed25519 | awk '{print $1,$2}')" != "$(awk '{print $1,$2}' ~/.ssh/id_ed25519.pub)" ]; then
+            echo "::error::HCLOUD_SSH_PRIVATE_KEY does not match HCLOUD_SSH_PUBLIC_KEY (key material differs)"
+            exit 1
+          fi
 
       - name: Terraform init
         working-directory: infrastructure/cluster
@@ -138,11 +154,27 @@ jobs:
       - name: Setup SSH key
         env:
           HCLOUD_SSH_PRIVATE_KEY: ${{ secrets.HCLOUD_SSH_PRIVATE_KEY }}
+          HCLOUD_SSH_PUBLIC_KEY: ${{ vars.HCLOUD_SSH_PUBLIC_KEY }}
         run: |
           mkdir -p ~/.ssh
           printenv HCLOUD_SSH_PRIVATE_KEY > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keygen -y -f ~/.ssh/id_ed25519 > ~/.ssh/id_ed25519.pub
+          # Write the CANONICAL public key (matches the key registered in Hetzner +
+          # tracked in TF state, comment included). Deriving it via `ssh-keygen -y`
+          # drops the comment and causes a spurious hcloud_ssh_key replacement in
+          # the plan (#131).
+          # Normalize: strip any stray CR/newlines the variable store may have
+          # added, then write exactly one trailing newline so the file matches
+          # the key in TF state byte-for-byte (else a trailing-newline mismatch
+          # still forces a spurious replacement).
+          printf '%s\n' "$(printf '%s' "$HCLOUD_SSH_PUBLIC_KEY" | tr -d '\r\n')" > ~/.ssh/id_ed25519.pub
+          # Guard: the private key secret must actually correspond to that public
+          # key. A byte-correct .pub with a wrong/rotated private key yields a clean
+          # plan but an apply that fails on the kustomization's SSH remote-exec.
+          if [ "$(ssh-keygen -y -f ~/.ssh/id_ed25519 | awk '{print $1,$2}')" != "$(awk '{print $1,$2}' ~/.ssh/id_ed25519.pub)" ]; then
+            echo "::error::HCLOUD_SSH_PRIVATE_KEY does not match HCLOUD_SSH_PUBLIC_KEY (key material differs)"
+            exit 1
+          fi
 
       - name: Terraform init
         working-directory: infrastructure/cluster

--- a/infrastructure/cluster/main.tf
+++ b/infrastructure/cluster/main.tf
@@ -80,16 +80,32 @@ module "kube-hetzner" {
   # Use stable k3s release channel
   initial_k3s_channel = "stable"
 
+  # PIN Traefik — a load-bearing ingress must never float on a k3s/chart
+  # auto-upgrade. An unpinned bump to v3.7.1 (needs Gateway API v1.5.1, TLSRoute
+  # Standard at v1) against v1.4.0 CRDs caused the 2026-05-29 ingress outage
+  # (zero HTTP routers, all hosts 404). Pinned to the version that is running
+  # and healthy. Traefik and the Gateway API CRDs are a COMPATIBILITY SET:
+  # bump this together with infrastructure/cluster-services/gateway-api-crds/.
+  # See issue #131.
+  traefik_version   = "40.2.0"
+  traefik_image_tag = "v3.7.1"
+
   # Gateway API: enable Traefik's kubernetesGateway provider.
-  # CRDs are bundled by the Traefik Helm chart; cert-manager Gateway API
-  # support is enabled automatically by kube-hetzner when this flag is set.
+  # CRDs are owned explicitly by the gateway-api-crds ArgoCD app (the v40 chart
+  # no longer bundles them); cert-manager Gateway API support is enabled
+  # automatically by kube-hetzner when this flag is set.
   traefik_provider_kubernetes_gateway_enabled = true
 
   # Deep-merge into defaults (preserves LB annotations, proxy protocol,
   # resource limits, PDB that traefik_values would silently drop).
-  # v2.19+ defaults are v39-compatible (no globalArguments, correct
-  # ports.web.http.redirections path), so merge-only is sufficient.
   traefik_merge_values = <<-EOT
+providers:
+  kubernetesGateway:
+    enabled: true
+    # Hearthly uses only HTTPRoute. false keeps TCPRoute out of the watch set.
+    # (TLSRoute is Standard in Gateway API v1.5, so this does not exclude it —
+    # that is satisfied by the owned v1.5.1 CRDs, not by this flag.)
+    experimentalChannel: false
 gateway:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod

--- a/infrastructure/cluster/main.tf
+++ b/infrastructure/cluster/main.tf
@@ -90,6 +90,17 @@ module "kube-hetzner" {
   traefik_version   = "40.2.0"
   traefik_image_tag = "v3.7.1"
 
+  # PIN the add-ons that otherwise float to GitHub "latest" via github_release
+  # data sources when unset (data.tf). The module re-renders ALL of these into
+  # terraform_data.kustomization; since pinning Traefik forces that kustomization
+  # to re-apply, any newly-released hccm/CSI/kured would silently roll in during
+  # the same maintenance event — the exact uncontrolled-float class that took
+  # ingress down (#131). Pinned to the versions currently running and healthy;
+  # bump deliberately. (kured tag has no leading "v"; hccm/CSI tags do.)
+  hetzner_ccm_version = "v1.30.1"
+  hetzner_csi_version = "v2.20.0"
+  kured_version       = "1.21.0"
+
   # Gateway API: enable Traefik's kubernetesGateway provider.
   # CRDs are owned explicitly by the gateway-api-crds ArgoCD app (the v40 chart
   # no longer bundles them); cert-manager Gateway API support is enabled


### PR DESCRIPTION
Pins the load-bearing add-on **compatibility set** so nothing floats on a kustomization re-apply — the uncontrolled-float class that caused the 2026-05-29 ingress outage.

## Changes
- **Traefik** pinned to the running healthy version (chart `40.2.0` / image `v3.7.1`) + `experimentalChannel: false`. Safe now that the Gateway API v1.5.1 CRDs are owned in Git (#139).
- **hccm `v1.30.1` / CSI `v2.20.0` / kured `1.21.0`** pinned to running versions. These otherwise resolve to `github_release` *latest* (data.tf); since pinning Traefik forces `terraform_data.kustomization` to re-apply, an unpinned add-on would silently upgrade in the same event. (Codex review finding.)
- **SSH**: write the canonical public key (comment included, matches Hetzner + TF state) from `vars.HCLOUD_SSH_PUBLIC_KEY` instead of deriving via `ssh-keygen -y` (which drops the comment → spurious `hcloud_ssh_key` replacement). Adds a private/public key-match guard before Terraform runs.

## Plan gate (verified locally against the reconciled state)
`Plan: 2 to add, 0 to change, 2 to destroy` — only `terraform_data.kustomization` (controlled re-apply, pinned manifests) + the benign `local_file` backup. **No LB / ssh_key / server / node / subnet changes** (the LB state drift was already reconciled).

## ⚠️ This is NOT the freeze-lift
Correcting the earlier note: the kustomization re-apply does **not** un-pause kured (it's a plain `kubectl apply -k`, no prune; kured's freeze is a `nodeSelector` the manifest doesn't manage). The freeze is lifted **explicitly and sequentially after merge** (uncordon lun → kured → system-upgrade, each watched), per the Codex review.

Part of #131.