### PR TITLE
fix(infra): bootstrap secrets from GitHub Encrypted Secrets, not Infisical (#131)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -16,12 +16,13 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  id-token: write
 
-env:
-  INFISICAL_IDENTITY_ID: '2a105da8-c31f-4244-b1f0-a72d5379bf4f'
-  INFISICAL_DOMAIN: 'https://secrets.hearthly.dev'
-  INFISICAL_PROJECT_SLUG: 'hearthly-uv-ci'
+# Bootstrap secrets come from GitHub Encrypted Secrets, NOT Infisical.
+# Rationale (#131, Task C.4): Infisical runs *inside* the cluster this workflow
+# builds/repairs. Fetching bootstrap creds from it created a proven circular
+# dependency — a sick cluster (or flapping ingress) broke Terraform, which was
+# the tool meant to fix the cluster. The recovery path must not depend on the
+# thing being recovered. See infrastructure/cluster/BOOTSTRAP.md.
 
 jobs:
   changes:
@@ -50,20 +51,15 @@ jobs:
     concurrency:
       group: terraform-cluster
       cancel-in-progress: false
+    env:
+      S3_ACCESS_KEY: ${{ secrets.TF_S3_ACCESS_KEY }}
+      S3_SECRET_KEY: ${{ secrets.TF_S3_SECRET_KEY }}
+      HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+      HCLOUD_SSH_PRIVATE_KEY: ${{ secrets.HCLOUD_SSH_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v6
 
       - uses: hashicorp/setup-terraform@v4
-
-      - name: Fetch secrets from Infisical
-        uses: Infisical/secrets-action@v1.0.15
-        with:
-          method: 'oidc'
-          identity-id: ${{ env.INFISICAL_IDENTITY_ID }}
-          domain: ${{ env.INFISICAL_DOMAIN }}
-          env-slug: 'prod'
-          project-slug: ${{ env.INFISICAL_PROJECT_SLUG }}
-          secret-path: '/'
 
       - name: Configure backend
         working-directory: infrastructure/cluster
@@ -114,20 +110,15 @@ jobs:
     concurrency:
       group: terraform-cluster
       cancel-in-progress: false
+    env:
+      S3_ACCESS_KEY: ${{ secrets.TF_S3_ACCESS_KEY }}
+      S3_SECRET_KEY: ${{ secrets.TF_S3_SECRET_KEY }}
+      HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+      HCLOUD_SSH_PRIVATE_KEY: ${{ secrets.HCLOUD_SSH_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v6
 
       - uses: hashicorp/setup-terraform@v4
-
-      - name: Fetch secrets from Infisical
-        uses: Infisical/secrets-action@v1.0.15
-        with:
-          method: 'oidc'
-          identity-id: ${{ env.INFISICAL_IDENTITY_ID }}
-          domain: ${{ env.INFISICAL_DOMAIN }}
-          env-slug: 'prod'
-          project-slug: ${{ env.INFISICAL_PROJECT_SLUG }}
-          secret-path: '/'
 
       - name: Configure backend
         working-directory: infrastructure/cluster
@@ -163,20 +154,16 @@ jobs:
     concurrency:
       group: terraform-keycloak-config
       cancel-in-progress: false
+    env:
+      S3_ACCESS_KEY: ${{ secrets.TF_S3_ACCESS_KEY }}
+      S3_SECRET_KEY: ${{ secrets.TF_S3_SECRET_KEY }}
+      KEYCLOAK_ADMIN_PASSWORD: ${{ secrets.KEYCLOAK_ADMIN_PASSWORD }}
+      GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+      GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
     steps:
       - uses: actions/checkout@v6
 
       - uses: hashicorp/setup-terraform@v4
-
-      - name: Fetch secrets from Infisical
-        uses: Infisical/secrets-action@v1.0.15
-        with:
-          method: 'oidc'
-          identity-id: ${{ env.INFISICAL_IDENTITY_ID }}
-          domain: ${{ env.INFISICAL_DOMAIN }}
-          env-slug: 'prod'
-          project-slug: ${{ env.INFISICAL_PROJECT_SLUG }}
-          secret-path: '/'
 
       - name: Configure backend
         working-directory: infrastructure/keycloak-config
@@ -222,20 +209,16 @@ jobs:
     concurrency:
       group: terraform-keycloak-config
       cancel-in-progress: false
+    env:
+      S3_ACCESS_KEY: ${{ secrets.TF_S3_ACCESS_KEY }}
+      S3_SECRET_KEY: ${{ secrets.TF_S3_SECRET_KEY }}
+      KEYCLOAK_ADMIN_PASSWORD: ${{ secrets.KEYCLOAK_ADMIN_PASSWORD }}
+      GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+      GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
     steps:
       - uses: actions/checkout@v6
 
       - uses: hashicorp/setup-terraform@v4
-
-      - name: Fetch secrets from Infisical
-        uses: Infisical/secrets-action@v1.0.15
-        with:
-          method: 'oidc'
-          identity-id: ${{ env.INFISICAL_IDENTITY_ID }}
-          domain: ${{ env.INFISICAL_DOMAIN }}
-          env-slug: 'prod'
-          project-slug: ${{ env.INFISICAL_PROJECT_SLUG }}
-          secret-path: '/'
 
       - name: Configure backend
         working-directory: infrastructure/keycloak-config

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -23,6 +23,11 @@ permissions:
 # dependency — a sick cluster (or flapping ingress) broke Terraform, which was
 # the tool meant to fix the cluster. The recovery path must not depend on the
 # thing being recovered. See infrastructure/cluster/BOOTSTRAP.md.
+#
+# Secrets are scoped to the individual steps that need them (least privilege),
+# so the PR-comment step carries no secrets in its environment. Terraform plan
+# text is passed to actions/github-script via env: (data), never interpolated
+# into the script body, to avoid a plan-text -> JS injection / secret-exfil path.
 
 jobs:
   changes:
@@ -51,11 +56,6 @@ jobs:
     concurrency:
       group: terraform-cluster
       cancel-in-progress: false
-    env:
-      S3_ACCESS_KEY: ${{ secrets.TF_S3_ACCESS_KEY }}
-      S3_SECRET_KEY: ${{ secrets.TF_S3_SECRET_KEY }}
-      HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
-      HCLOUD_SSH_PRIVATE_KEY: ${{ secrets.HCLOUD_SSH_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v6
 
@@ -63,6 +63,9 @@ jobs:
 
       - name: Configure backend
         working-directory: infrastructure/cluster
+        env:
+          S3_ACCESS_KEY: ${{ secrets.TF_S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.TF_S3_SECRET_KEY }}
         run: |
           cat > backend.conf <<EOF
           access_key = "$S3_ACCESS_KEY"
@@ -71,6 +74,8 @@ jobs:
           sed -i 's/^ *//' backend.conf
 
       - name: Setup SSH key
+        env:
+          HCLOUD_SSH_PRIVATE_KEY: ${{ secrets.HCLOUD_SSH_PRIVATE_KEY }}
         run: |
           mkdir -p ~/.ssh
           printenv HCLOUD_SSH_PRIVATE_KEY > ~/.ssh/id_ed25519
@@ -86,16 +91,19 @@ jobs:
         working-directory: infrastructure/cluster
         run: terraform plan -input=false -no-color -out=tfplan
         env:
-          TF_VAR_hcloud_token: ${{ env.HCLOUD_TOKEN }}
+          TF_VAR_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
 
       - name: Post plan to PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
+        env:
+          PLAN: ${{ steps.plan.outputs.stdout }}
+          ACTOR: ${{ github.actor }}
         with:
           script: |
-            let plan = `${{ steps.plan.outputs.stdout }}`;
+            let plan = process.env.PLAN || '';
             if (plan.length > 60000) plan = plan.substring(0, 60000) + '\n... (truncated)';
-            const output = `#### Terraform Plan — \`infrastructure/cluster\`\n\`\`\`\n${plan}\n\`\`\`\n*Triggered by @${{ github.actor }}*`;
+            const output = `#### Terraform Plan — \`infrastructure/cluster\`\n\`\`\`\n${plan}\n\`\`\`\n*Triggered by @${process.env.ACTOR}*`;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
@@ -110,11 +118,6 @@ jobs:
     concurrency:
       group: terraform-cluster
       cancel-in-progress: false
-    env:
-      S3_ACCESS_KEY: ${{ secrets.TF_S3_ACCESS_KEY }}
-      S3_SECRET_KEY: ${{ secrets.TF_S3_SECRET_KEY }}
-      HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
-      HCLOUD_SSH_PRIVATE_KEY: ${{ secrets.HCLOUD_SSH_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v6
 
@@ -122,6 +125,9 @@ jobs:
 
       - name: Configure backend
         working-directory: infrastructure/cluster
+        env:
+          S3_ACCESS_KEY: ${{ secrets.TF_S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.TF_S3_SECRET_KEY }}
         run: |
           cat > backend.conf <<EOF
           access_key = "$S3_ACCESS_KEY"
@@ -130,6 +136,8 @@ jobs:
           sed -i 's/^ *//' backend.conf
 
       - name: Setup SSH key
+        env:
+          HCLOUD_SSH_PRIVATE_KEY: ${{ secrets.HCLOUD_SSH_PRIVATE_KEY }}
         run: |
           mkdir -p ~/.ssh
           printenv HCLOUD_SSH_PRIVATE_KEY > ~/.ssh/id_ed25519
@@ -144,7 +152,7 @@ jobs:
         working-directory: infrastructure/cluster
         run: terraform apply -input=false -auto-approve
         env:
-          TF_VAR_hcloud_token: ${{ env.HCLOUD_TOKEN }}
+          TF_VAR_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
 
   # --- Keycloak config module ---
   plan-keycloak-config:
@@ -154,12 +162,6 @@ jobs:
     concurrency:
       group: terraform-keycloak-config
       cancel-in-progress: false
-    env:
-      S3_ACCESS_KEY: ${{ secrets.TF_S3_ACCESS_KEY }}
-      S3_SECRET_KEY: ${{ secrets.TF_S3_SECRET_KEY }}
-      KEYCLOAK_ADMIN_PASSWORD: ${{ secrets.KEYCLOAK_ADMIN_PASSWORD }}
-      GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-      GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
     steps:
       - uses: actions/checkout@v6
 
@@ -167,6 +169,9 @@ jobs:
 
       - name: Configure backend
         working-directory: infrastructure/keycloak-config
+        env:
+          S3_ACCESS_KEY: ${{ secrets.TF_S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.TF_S3_SECRET_KEY }}
         run: |
           cat > backend.conf <<EOF
           access_key = "$S3_ACCESS_KEY"
@@ -183,18 +188,21 @@ jobs:
         working-directory: infrastructure/keycloak-config
         run: terraform plan -input=false -no-color -out=tfplan
         env:
-          TF_VAR_keycloak_admin_password: ${{ env.KEYCLOAK_ADMIN_PASSWORD }}
-          TF_VAR_google_client_id: ${{ env.GOOGLE_CLIENT_ID }}
-          TF_VAR_google_client_secret: ${{ env.GOOGLE_CLIENT_SECRET }}
+          TF_VAR_keycloak_admin_password: ${{ secrets.KEYCLOAK_ADMIN_PASSWORD }}
+          TF_VAR_google_client_id: ${{ secrets.GOOGLE_CLIENT_ID }}
+          TF_VAR_google_client_secret: ${{ secrets.GOOGLE_CLIENT_SECRET }}
 
       - name: Post plan to PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
+        env:
+          PLAN: ${{ steps.plan.outputs.stdout }}
+          ACTOR: ${{ github.actor }}
         with:
           script: |
-            let plan = `${{ steps.plan.outputs.stdout }}`;
+            let plan = process.env.PLAN || '';
             if (plan.length > 60000) plan = plan.substring(0, 60000) + '\n... (truncated)';
-            const output = `#### Terraform Plan — \`infrastructure/keycloak-config\`\n\`\`\`\n${plan}\n\`\`\`\n*Triggered by @${{ github.actor }}*`;
+            const output = `#### Terraform Plan — \`infrastructure/keycloak-config\`\n\`\`\`\n${plan}\n\`\`\`\n*Triggered by @${process.env.ACTOR}*`;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
@@ -209,12 +217,6 @@ jobs:
     concurrency:
       group: terraform-keycloak-config
       cancel-in-progress: false
-    env:
-      S3_ACCESS_KEY: ${{ secrets.TF_S3_ACCESS_KEY }}
-      S3_SECRET_KEY: ${{ secrets.TF_S3_SECRET_KEY }}
-      KEYCLOAK_ADMIN_PASSWORD: ${{ secrets.KEYCLOAK_ADMIN_PASSWORD }}
-      GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-      GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
     steps:
       - uses: actions/checkout@v6
 
@@ -222,6 +224,9 @@ jobs:
 
       - name: Configure backend
         working-directory: infrastructure/keycloak-config
+        env:
+          S3_ACCESS_KEY: ${{ secrets.TF_S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.TF_S3_SECRET_KEY }}
         run: |
           cat > backend.conf <<EOF
           access_key = "$S3_ACCESS_KEY"
@@ -237,6 +242,6 @@ jobs:
         working-directory: infrastructure/keycloak-config
         run: terraform apply -input=false -auto-approve
         env:
-          TF_VAR_keycloak_admin_password: ${{ env.KEYCLOAK_ADMIN_PASSWORD }}
-          TF_VAR_google_client_id: ${{ env.GOOGLE_CLIENT_ID }}
-          TF_VAR_google_client_secret: ${{ env.GOOGLE_CLIENT_SECRET }}
+          TF_VAR_keycloak_admin_password: ${{ secrets.KEYCLOAK_ADMIN_PASSWORD }}
+          TF_VAR_google_client_id: ${{ secrets.GOOGLE_CLIENT_ID }}
+          TF_VAR_google_client_secret: ${{ secrets.GOOGLE_CLIENT_SECRET }}

--- a/infrastructure/CLAUDE.md
+++ b/infrastructure/CLAUDE.md
@@ -97,7 +97,7 @@ Default-deny both ingress and egress per namespace. 35 policies across 6 namespa
 
 - **CI:** `ci.yml` — lint, test, build affected (x86, Node.js 24)
 - **Deploy:** `deploy.yml` — builds API, App, Keycloak on ARM64 runners, Trivy scan before push
-- **Terraform:** `terraform.yml` — plan on PR (posted as comment), apply on merge. CI fetches secrets via Infisical OIDC (identity ID and project slug hardcoded in workflow).
+- **Terraform:** `terraform.yml` — plan on PR (posted as comment), apply on merge. CI reads bootstrap secrets from **GitHub Encrypted Secrets** (NOT Infisical) — see `cluster/BOOTSTRAP.md`. Infisical runs inside the cluster Terraform repairs, so fetching bootstrap creds from it was a proven circular dependency during the 2026-05 outage (#131, Task C.4). The duplicated secrets (`S3_*`, `KEYCLOAK_ADMIN_PASSWORD`) stay in Infisical for in-cluster consumers; rotate in Infisical **and** re-set the GitHub Secret.
 - **ARM64 runners require public repo** — if repo goes private, Docker build jobs fail
 - **Terraform concurrency:** serialized per module (`cancel-in-progress: false`) — Hetzner S3 has no state locking. **No manual `terraform apply` while CI is running.**
 

--- a/infrastructure/cluster/BOOTSTRAP.md
+++ b/infrastructure/cluster/BOOTSTRAP.md
@@ -1,0 +1,65 @@
+# Bootstrap Secrets Inventory
+
+> Every credential needed to **build or recover the cluster from cold**, where it lives,
+> and which layer is authoritative. Tracked under issue #131, Task C.4.
+
+## Principle
+
+**The recovery path must not depend on the thing being recovered.**
+
+Infisical (`secrets.hearthly.dev`) runs _inside_ the k3s cluster, behind its ingress.
+If the Terraform workflow fetched its credentials from Infisical, then a sick cluster (or
+a flapping ingress) would break Terraform — the very tool meant to rebuild the cluster.
+This was a **proven** failure during the 2026-05 outage: the Terraform workflow failed
+mid-incident on Infisical 502 / self-signed-cert errors.
+
+Therefore the small set of **Terraform bootstrap secrets** lives in **GitHub Encrypted
+Secrets** (outside the cluster), so `terraform apply` and a cold rebuild work even when the
+cluster — and Infisical — is completely down.
+
+Application/runtime secrets stay in Infisical. Only bootstrap/recovery credentials move out.
+
+## Terraform bootstrap secrets (consumed by `.github/workflows/terraform.yml`)
+
+| Infisical name            | GitHub Secret name        | Used by (out-of-cluster)                                  | Also consumed in-cluster?                                                                                           | Source of truth                       |
+| ------------------------- | ------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `S3_ACCESS_KEY`           | `TF_S3_ACCESS_KEY`        | TF state backend (both modules)                           | **Yes** — DB-backup CronJobs (`hearthly-managed-secrets`, `keycloak-s3-credentials`)                                | Infisical (canonical) + GitHub mirror |
+| `S3_SECRET_KEY`           | `TF_S3_SECRET_KEY`        | TF state backend (both modules)                           | **Yes** — same as above                                                                                             | Infisical (canonical) + GitHub mirror |
+| `HCLOUD_TOKEN`            | `HCLOUD_TOKEN`            | cluster module (Hetzner provider + `TF_VAR_hcloud_token`) | Indirectly — kube-hetzner writes the in-cluster `hcloud` Secret (hccm/CSI) **from this TF var**, not from Infisical | GitHub                                |
+| `HCLOUD_SSH_PRIVATE_KEY`  | `HCLOUD_SSH_PRIVATE_KEY`  | cluster module (node SSH) + manual operator SSH           | No automated in-cluster consumer                                                                                    | GitHub                                |
+| `KEYCLOAK_ADMIN_PASSWORD` | `KEYCLOAK_ADMIN_PASSWORD` | keycloak-config module                                    | **Yes** — Keycloak pod (`keycloak-admin-credentials`)                                                               | Infisical (canonical) + GitHub mirror |
+| `GOOGLE_CLIENT_ID`        | `GOOGLE_CLIENT_ID`        | keycloak-config module (Google IdP)                       | No (TF writes it into Keycloak's own DB)                                                                            | GitHub                                |
+| `GOOGLE_CLIENT_SECRET`    | `GOOGLE_CLIENT_SECRET`    | keycloak-config module (Google IdP)                       | No                                                                                                                  | GitHub                                |
+
+The workflow maps each GitHub Secret back to the **exact env-var name** Terraform expects
+(`S3_ACCESS_KEY`, `HCLOUD_TOKEN`, etc.) via per-job `env:` blocks — only the two S3 keys are
+renamed (`TF_` prefix) on the GitHub side to avoid a generic collision.
+
+## Source-of-truth & rotation rules
+
+- **GitHub-only** (`HCLOUD_TOKEN`, `HCLOUD_SSH_PRIVATE_KEY`, `GOOGLE_CLIENT_ID`,
+  `GOOGLE_CLIENT_SECRET`): nothing in-cluster reads these _from Infisical_. They may remain
+  in Infisical as dead weight but it can be deleted there; **GitHub is authoritative**.
+- **Duplicated — GitHub + Infisical** (`S3_ACCESS_KEY`, `S3_SECRET_KEY`,
+  `KEYCLOAK_ADMIN_PASSWORD`): real in-cluster consumers sync these from Infisical, so they
+  must stay there too. **Infisical is the human-facing source of truth; the GitHub copy is
+  the bootstrap mirror.** When rotating one of these: **update Infisical first, then re-set
+  the matching GitHub Secret** (`gh secret set …`). They do not auto-sync.
+- **Pure-CI credentials** (e.g. a future read-only `ARGOCD_TOKEN` for deploy verification):
+  no cluster meaning → **GitHub-only, never add to Infisical**.
+
+## Other cold-rebuild dependencies (in-cluster bootstrap — tracked for the cold-recovery runbook, Task D.7)
+
+Not part of the Terraform-secret move above, but required to bring a freshly-rebuilt cluster
+back to a synced state. Listed here so the cold-recovery runbook (D.7) is complete:
+
+| Item                                                                   | Today                     | Notes                                                                                                                                                  |
+| ---------------------------------------------------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| ArgoCD repo token (`hearthly-repo` Secret, argocd ns)                  | manual K8s Secret         | HTTPS + GitHub token; SSH blocked by Hetzner firewall                                                                                                  |
+| GHCR image pull secret                                                 | manual K8s Secret         | pulls `ghcr.io/rudingma/*` images                                                                                                                      |
+| Infisical machine identity (`infisical-machine-identity`, hearthly ns) | manual K8s Secret         | universal-auth `clientId`/`clientSecret`; must exist before InfisicalSecret CRs in keycloak/monitoring can sync (cross-namespace bootstrap dependency) |
+| cert-manager `letsencrypt-prod` ClusterIssuer                          | manual `kubectl apply`    | `infrastructure/cluster-services/cert-manager/clusterissuer.yaml` — intentionally not ArgoCD-managed                                                   |
+| `NTFY_TOPIC` (alerting)                                                | Infisical + GitHub Secret | already mirrored in GitHub (external healthcheck uses it)                                                                                              |
+
+These should be sourced from GitHub-backed bootstrap manifests as part of D.7; until then they
+are documented manual steps in the cold-recovery procedure.


### PR DESCRIPTION
## What & why

Task **C.4** of the cluster-resilience hardening (#131). The Terraform GitHub Actions workflow previously fetched its 7 bootstrap secrets at runtime from **Infisical** (`secrets.hearthly.dev`) via `Infisical/secrets-action` OIDC, in all 4 jobs.

Infisical runs **inside the same k3s cluster this workflow builds and repairs** → a proven circular dependency: during the 2026-05 outage, Terraform failed mid-incident because Infisical (behind the cluster ingress) was unreachable. *The recovery path must not depend on the thing being recovered.*

## Change

- Drop the 4 `Fetch secrets from Infisical` OIDC steps; read the 7 secrets from **GitHub Encrypted Secrets**.
- Remove the top-level `INFISICAL_*` env block and the now-unused `id-token: write` permission.
- Secrets are **step-scoped** (least privilege) — the PR-comment step carries no secrets.
- Plan text reaches `actions/github-script` via `env:` (data), not `${{ }}`-interpolated into the JS body — closes a plan-text → JS injection / secret-exfil path.
- Add `infrastructure/cluster/BOOTSTRAP.md` (inventory + source-of-truth & rotation rules) and update `infrastructure/CLAUDE.md`.

The 7 GitHub secrets are already set: `TF_S3_ACCESS_KEY`, `TF_S3_SECRET_KEY`, `HCLOUD_TOKEN`, `HCLOUD_SSH_PRIVATE_KEY`, `KEYCLOAK_ADMIN_PASSWORD`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`. The duplicated ones (`S3_*`, `KEYCLOAK_ADMIN_PASSWORD`) remain in Infisical for in-cluster consumers; rotation rule documented in `BOOTSTRAP.md`.

## Review

Pressure-tested with a Codex adversarial review. It flagged the `github-script` injection/secret-exfil path; both its recommendations (step-scoping + passing plan text via `env`) are applied in `8fb40f7`.

## Safety

This PR touches no `.tf` file, so it triggers **no** Terraform plan/apply. Live credential validation happens at the first `.tf` plan in the next task (Terraform state-drift reconcile).

Part of #131.