### PR TITLE
feat(monitoring): fail-loud ingress alerts via blackbox probes (#131)

### DIFF
--- a/infrastructure/cluster-services/monitoring/templates/blackbox-exporter.yaml
+++ b/infrastructure/cluster-services/monitoring/templates/blackbox-exporter.yaml
@@ -1,0 +1,100 @@
+# Synthetic ingress probing — the 2026-05 outage was SILENT in-cluster: Traefik
+# built zero HTTP routers and every host 404'd, but nothing alerted. blackbox-exporter
+# probes each public host end-to-end (DNS -> LB -> Traefik -> service) so a broken
+# ingress fires loudly via the existing Alertmanager -> ntfy path. See issue #131.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blackbox-exporter
+  namespace: {{ .Release.Namespace }}
+data:
+  blackbox.yml: |
+    modules:
+      ingress_http:
+        prober: http
+        timeout: 8s
+        http:
+          method: GET
+          # "Alive" codes: a routed host returns one of these. A broken ingress
+          # (no Traefik router) returns 404, or 5xx/timeout -> probe_success=0.
+          valid_status_codes: [200, 301, 302, 303, 307, 308, 401, 403]
+          fail_if_not_ssl: true
+          preferred_ip_protocol: ip4
+          ip_protocol_fallback: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: blackbox-exporter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: blackbox-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: blackbox-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: blackbox-exporter
+      annotations:
+        checksum/config: {{ .Files.Get "templates/blackbox-exporter.yaml" | sha256sum | trunc 16 }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: blackbox-exporter
+          image: quay.io/prometheus/blackbox-exporter:v0.25.0
+          args:
+            - --config.file=/etc/blackbox/blackbox.yml
+          ports:
+            - name: http
+              containerPort: 9115
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http
+          volumeMounts:
+            - name: config
+              mountPath: /etc/blackbox
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: blackbox-exporter
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: blackbox-exporter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: blackbox-exporter
+spec:
+  selector:
+    app.kubernetes.io/name: blackbox-exporter
+  ports:
+    - name: http
+      port: 9115
+      targetPort: http

--- a/infrastructure/cluster-services/monitoring/templates/probe-ingress.yaml
+++ b/infrastructure/cluster-services/monitoring/templates/probe-ingress.yaml
@@ -1,0 +1,30 @@
+# Probe each public ingress host through blackbox-exporter. The `release: monitoring`
+# label is required for the Prometheus operator's probeSelector to pick it up
+# (same convention as the kured PodMonitor). See issue #131.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: ingress-hosts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: monitoring
+spec:
+  jobName: ingress-blackbox
+  interval: 30s
+  scrapeTimeout: 10s
+  module: ingress_http
+  prober:
+    url: blackbox-exporter.{{ .Release.Namespace }}.svc.cluster.local:9115
+    scheme: http
+    path: /probe
+  targets:
+    staticConfig:
+      static:
+        - https://hearthly.dev/
+        - https://api.hearthly.dev/health
+        - https://auth.hearthly.dev/
+        - https://argocd.hearthly.dev/
+        - https://grafana.hearthly.dev/
+        - https://secrets.hearthly.dev/
+      labels:
+        probe_group: ingress

--- a/infrastructure/cluster-services/monitoring/templates/prometheusrule-ingress.yaml
+++ b/infrastructure/cluster-services/monitoring/templates/prometheusrule-ingress.yaml
@@ -1,0 +1,40 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: ingress-blackbox
+  namespace: {{ .Release.Namespace }}
+spec:
+  groups:
+    - name: ingress
+      rules:
+        # A routed, healthy host returns an "alive" status (200/30x/40x auth).
+        # probe_success=0 means: connection/TLS/timeout failure, a 404 (no Traefik
+        # router — the 2026-05 outage signature), or a 5xx. Fire loudly.
+        - alert: IngressHostDown
+          expr: probe_success{job="ingress-blackbox"} == 0
+          for: 3m
+          labels:
+            severity: critical
+          annotations:
+            summary: 'Ingress host {{ "{{ $labels.instance }}" }} is not serving correctly'
+            description: 'blackbox probe of {{ "{{ $labels.instance }}" }} has failed for 3m — a connection/TLS/timeout failure, a 404 (no Traefik router — the 2026-05 outage signature), or a 5xx. Check Traefik routing, the cert, and the LB (#131).'
+        # The full-outage signature: EVERY host failing at once = Traefik built zero
+        # routers (e.g. Gateway API CRD skew). Fire fast.
+        - alert: IngressAllHostsDown
+          expr: count(probe_success{job="ingress-blackbox"} == 0) == count(probe_success{job="ingress-blackbox"})
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: 'ALL ingress hosts are failing — full ingress outage'
+            description: 'Every probed host is failing. Traefik likely built zero HTTP routers (the 2026-05-29 outage signature — Traefik/Gateway-API CRD skew). Check Traefik and infrastructure/cluster-services/gateway-api-crds/.'
+        # The probe pipeline itself must not go dark (that is how the outage stayed
+        # silent for 16 days).
+        - alert: IngressProbesNoData
+          expr: absent(probe_success{job="ingress-blackbox"})
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: 'Ingress blackbox probes are returning no data'
+            description: 'No probe_success series for job ingress-blackbox — blackbox-exporter may be down or unscraped, leaving ingress UNMONITORED.'

--- a/infrastructure/cluster-services/monitoring/values.yaml
+++ b/infrastructure/cluster-services/monitoring/values.yaml
@@ -88,13 +88,15 @@ kube-prometheus-stack:
               requests:
                 storage: 10Gi
 
-      # Discover ALL PrometheusRules, ServiceMonitors and PodMonitors, not
+      # Discover ALL PrometheusRules, ServiceMonitors, PodMonitors and Probes, not
       # just those with a release label matching this Helm chart. Required for
       # custom rules in wrapper chart templates, cross-namespace ServiceMonitors,
-      # and the kured PodMonitor (kured is a raw DaemonSet in kube-system).
+      # the kured PodMonitor (kured is a raw DaemonSet in kube-system), and the
+      # ingress blackbox Probe.
       ruleSelectorNilUsesHelmValues: false
       serviceMonitorSelectorNilUsesHelmValues: false
       podMonitorSelectorNilUsesHelmValues: false
+      probeSelectorNilUsesHelmValues: false
 
   # --- Alertmanager → ntfy.sh via alertmanager-ntfy sidecar ---
   alertmanager:

--- a/infrastructure/network-policies/templates/monitoring.yaml
+++ b/infrastructure/network-policies/templates/monitoring.yaml
@@ -239,3 +239,47 @@ spec:
       ports:
         - port: 443
           protocol: TCP
+---
+# Blackbox exporter: synthetic ingress probes hit each public host end-to-end,
+# which means egress to the public LB IP (a non-cluster address) on 443, plus
+# DNS to resolve the hostnames. Without this the probes fail under default-deny
+# and fire false IngressHostDown alerts. Same external-egress shape as
+# alertmanager above. See issue #131.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-blackbox-probe-egress
+  namespace: monitoring
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: blackbox-exporter
+  policyTypes:
+    - Egress
+  egress:
+    # DNS resolution of the probed hostnames
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # External HTTPS — reach the public ingress LB to probe each host end-to-end
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - port: 443
+          protocol: TCP


### PR DESCRIPTION
## Why
The 2026-05 outage was **silent in-cluster** — Traefik built zero HTTP routers, every host 404'd, and nothing alerted (caught only by the external GitHub healthcheck, after 16 days). This adds the in-cluster "ingress is actually serving each host" signal.

## What
- **blackbox-exporter** (Deployment + Service + ConfigMap) — non-root, drop ALL caps, read-only rootfs, seccomp RuntimeDefault.
- **Probe** of all 6 public hosts end-to-end (`hearthly.dev`, `api`, `auth`, `argocd`, `grafana`, `secrets`) — DNS → LB → Traefik → service. In-cluster→public-LB hairpin confirmed working (200).
- **PrometheusRule** (`ingress`):
  - `IngressHostDown` — per host, `probe_success==0` for 3m (catches 404/no-router, 5xx, TLS/conn failure).
  - `IngressAllHostsDown` — every host failing at once = the zero-routers/full-outage signature; fires in 1m.
  - `IngressProbesNoData` — the probe pipeline itself went dark (how the outage stayed silent).
- **NetworkPolicy** `allow-blackbox-probe-egress` — blackbox → public LB:443 + DNS (monitoring ns is default-deny egress).
- `probeSelectorNilUsesHelmValues: false` so the operator discovers the Probe (consistent with the existing rule/SM/PM selectors).

Alerts route through the existing Alertmanager → ntfy path. Low-risk/additive: no changes to existing prod resources beyond one new egress policy + the operator's probe-discovery setting.

Verified: `helm template` renders both charts cleanly; Prettier + repo format gate pass. Post-merge I'll confirm the probes scrape (`probe_success` series) and the rules load.

Part of #131 (fail-loud ingress alerts).