### PR TITLE
fix(monitoring): raise kube-state-metrics CPU limit to stop liveness crashloop

### DIFF
--- a/infrastructure/cluster-services/monitoring/values.yaml
+++ b/infrastructure/cluster-services/monitoring/values.yaml
@@ -290,11 +290,20 @@ kube-prometheus-stack:
         memory: 64Mi
 
   # --- kube-state-metrics ---
+  # CPU limit raised 100m->300m: KSM bursts hard during its initial all-namespace
+  # list/watch. At 100m it was CFS-throttled enough that the /livez + /readyz HTTP
+  # handlers exceeded the 5s probe timeout, so the kubelet liveness-killed it in a
+  # crashloop (exit 2, NOT OOM) — leaving kube_* metrics absent and blinding most
+  # kube-prometheus-stack alerts. Nodes have ample CPU headroom (was ~16% used), so
+  # the container limit, not the node, was the bottleneck. Memory limit 64Mi->128Mi
+  # for headroom watching secrets/configmaps cluster-wide. (Distinct from the
+  # API-egress crashloop noted in infrastructure/CLAUDE.md — that one can't reach
+  # the API at all; this one syncs fine then dies on probe timeout.)
   kube-state-metrics:
     resources:
       requests:
         cpu: 20m
         memory: 32Mi
       limits:
-        cpu: 100m
-        memory: 64Mi
+        cpu: 300m
+        memory: 128Mi


### PR DESCRIPTION
## Problem
`monitoring-kube-state-metrics` was in `CrashLoopBackOff` (38+ restarts, chronic). Root cause confirmed from logs + events:

- KSM starts, reaches the API server, lists all resources — then dies with **exit code 2 (not OOM)**.
- Events: `Liveness probe failed: .../livez context deadline exceeded` + `Readiness probe failed: .../readyz context deadline exceeded` → `Container failed liveness probe, will be restarted`.
- The **100m CPU limit** CFS-throttled KSM during its bursty initial all-namespace list/watch (logs show client-side throttling with multi-second delays), starving the `/livez`+`/readyz` HTTP handlers so they exceeded the 5s probe timeout.
- Nodes had ample CPU headroom (~16% used) — the **container limit**, not the node, was the bottleneck.

With KSM down, `kube_pod_*` / `kube_deployment_*` / `kube_node_*` metrics are absent, blinding most kube-prometheus-stack alerts. That's an observability hole squarely under the **'observability fails loud'** pillar of the post-outage hardening (#131).

## Fix
- CPU limit `100m → 300m` (allow the startup burst; node CPU is plentiful).
- Memory limit `64Mi → 128Mi` (headroom watching secrets/configmaps cluster-wide; requests unchanged to avoid adding scheduling pressure on the memory-tight 4 GB nodes).

Distinct from the API-egress crashloop already documented in `infrastructure/CLAUDE.md` (that one can't reach the API at all; this one syncs fine then dies on the probe).

## Verification
- `helm template monitoring .` renders KSM with `limits: {cpu: 300m, memory: 128Mi}`.
- Prettier clean.
- Discovered while completing the lun k3s upgrade (A.4 tail) under #131.

Refs #131