### PR TITLE
feat(monitoring): scrape CNPG metrics via declarative PodMonitors

### DIFF
--- a/apps/hearthly-api/infra/database.yaml
+++ b/apps/hearthly-api/infra/database.yaml
@@ -42,3 +42,7 @@ spec:
     enablePodAntiAffinity: true
     topologyKey: kubernetes.io/hostname
     podAntiAffinityType: required
+
+  # NOTE: CNPG metrics are scraped via a manually-managed PodMonitor (see
+  # podmonitor.yaml in this directory), NOT spec.monitoring.enablePodMonitor —
+  # that field is deprecated in CNPG and scheduled for removal. See issue #131.

--- a/apps/hearthly-api/infra/podmonitor.yaml
+++ b/apps/hearthly-api/infra/podmonitor.yaml
@@ -1,0 +1,25 @@
+# Scrapes CNPG instance metrics (cnpg_* series) for hearthly-db.
+#
+# Managed manually rather than via spec.monitoring.enablePodMonitor (deprecated
+# in CNPG, scheduled for removal). Lives in the hearthly namespace alongside the
+# Cluster; kube-prometheus-stack discovers PodMonitors cluster-wide
+# (podMonitorSelectorNilUsesHelmValues=false). The Prometheus -> :9187 scrape
+# path is already open: networkpolicy-db.yaml allows monitoring ingress on 9187
+# and the monitoring chart's allow-prometheus-scraping covers egress.
+#
+# Feeds the CNPG alert rules (prometheusrule-cnpg.yaml). A single-instance DB
+# caused the 2026-05 outage and the DB had zero alerting — closing that gap.
+# See issue #131.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: hearthly-db
+  namespace: hearthly
+  labels:
+    cnpg.io/cluster: hearthly-db
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: hearthly-db
+  podMetricsEndpoints:
+    - port: metrics

--- a/infrastructure/cluster-services/keycloak/infra/database.yaml
+++ b/infrastructure/cluster-services/keycloak/infra/database.yaml
@@ -39,3 +39,7 @@ spec:
     enablePodAntiAffinity: true
     topologyKey: kubernetes.io/hostname
     podAntiAffinityType: required
+
+  # NOTE: CNPG metrics are scraped via a manually-managed PodMonitor (see
+  # podmonitor.yaml in this directory), NOT spec.monitoring.enablePodMonitor —
+  # that field is deprecated in CNPG and scheduled for removal. See issue #131.

--- a/infrastructure/cluster-services/keycloak/infra/podmonitor.yaml
+++ b/infrastructure/cluster-services/keycloak/infra/podmonitor.yaml
@@ -1,0 +1,20 @@
+# Scrapes CNPG instance metrics (cnpg_* series) for keycloak-db.
+#
+# Managed manually rather than via spec.monitoring.enablePodMonitor (deprecated
+# in CNPG, scheduled for removal). Lives in the keycloak namespace alongside the
+# Cluster; discovered cluster-wide. The Prometheus -> :9187 scrape path is
+# already open (networkpolicy-db.yaml monitoring ingress on 9187 +
+# allow-prometheus-scraping egress). Feeds prometheusrule-cnpg.yaml. See #131.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: keycloak-db
+  namespace: keycloak
+  labels:
+    cnpg.io/cluster: keycloak-db
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: keycloak-db
+  podMetricsEndpoints:
+    - port: metrics


### PR DESCRIPTION
## Why
CNPG metrics were **not scraped at all** — `0` `cnpg_*` series in Prometheus, no PodMonitor, `enablePodMonitor=false` on both clusters. So the HA databases (`hearthly-db`, `keycloak-db`) had **zero alerting**. A single-instance DB *caused* the 2026-05 outage (#131), so DB observability is a priority gap under the 'observability fails loud' pillar.

This is **step 1 of architecture-plan D.1**: enable scraping. The alert rules (`prometheusrule-cnpg.yaml`) follow in a second PR, once metrics are confirmed flowing with their exact names (avoids the silent no-data trap of alerting on a wrong metric name).

## What
- Add a `PodMonitor` per cluster (in the DB's own namespace) selecting CNPG instance pods on the named `metrics` port (9187).
- Managed **declaratively** rather than via `spec.monitoring.enablePodMonitor` — that field is **deprecated in CNPG and scheduled for removal** (confirmed via server-side dry-run warning + CNPG docs, which say to set it false and create the PodMonitor manually). Removed the implicit reliance; added a pointer comment in each Cluster spec.

## Path was already open (no NetworkPolicy change needed)
- Ingress: `networkpolicy-db.yaml` already allows `monitoring` namespace ingress on 9187 (both DBs).
- Egress: the monitoring chart's `allow-prometheus-scraping` allows egress to all namespaces.
- Discovery: `podMonitorSelectorNilUsesHelmValues=false` → Prometheus discovers PodMonitors cluster-wide (same mechanism that already works for the kured PodMonitor in kube-system).

## Verification
- Both instance pods expose the named port `metrics`=9187 (confirmed live).
- Both PodMonitors pass `kubectl apply --dry-run=server`.
- Cluster specs still validate; the deprecation warning is gone.
- Prettier clean.
- Post-merge: will confirm `cnpg_collector_up` + the cnpg_* series appear in Prometheus before writing the alert rules.

Refs #131