### PR TITLE
feat(monitoring): CNPG database alert rules

### DIFF
--- a/infrastructure/cluster-services/monitoring/templates/prometheusrule-cnpg.yaml
+++ b/infrastructure/cluster-services/monitoring/templates/prometheusrule-cnpg.yaml
@@ -1,0 +1,65 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cnpg-database
+  namespace: {{ .Release.Namespace }}
+spec:
+  groups:
+    - name: cnpg
+      rules:
+        # An instance's metrics collector cannot reach its local PostgreSQL =
+        # that instance is down or unhealthy. Per-instance (labels: namespace,
+        # pod). A single-instance DB that could not be drained caused the
+        # 2026-05 outage (#131) — instance health is now a first-class signal.
+        - alert: CnpgInstanceDown
+          expr: cnpg_collector_up == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: 'CNPG instance {{ "{{ $labels.pod }}" }} ({{ "{{ $labels.namespace }}" }}) is down'
+            description: 'cnpg_collector_up=0 for {{ "{{ $labels.pod }}" }} for 5m — the instance is unreachable/unhealthy. Check `kubectl get cluster -n {{ "{{ $labels.namespace }}" }}` and the pod logs.'
+        # The primary reports the number of STREAMING standbys; a healthy 2-node
+        # cluster has 1. If max-per-namespace drops below 1, the cluster has
+        # silently degraded to a single effective instance — exactly the
+        # fragility behind the 2026-05 outage (single-instance DB blocked the
+        # kured drain). Assumes every CNPG cluster here runs >= 2 instances
+        # (hearthly-db, keycloak-db both do). `for: 5m` rides out switchovers.
+        - alert: CnpgHAReplicaMissing
+          expr: max by (namespace) (cnpg_pg_replication_streaming_replicas) < 1
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: 'CNPG cluster in {{ "{{ $labels.namespace }}" }} has no streaming standby'
+            description: 'No standby is streaming from the primary in {{ "{{ $labels.namespace }}" }} for 5m — HA has degraded toward a single instance (the 2026-05 outage condition). A drain/reboot of the primary node would now risk downtime + block kured.'
+        # Async replication lag widening = growing RPO. Healthy is ~0s.
+        - alert: CnpgReplicationLagHigh
+          expr: cnpg_pg_replication_lag > 30
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: 'CNPG replication lag high in {{ "{{ $labels.namespace }}" }}'
+            description: 'Replication lag on {{ "{{ $labels.pod }}" }} has exceeded 30s for 10m (current {{ "{{ $value | humanizeDuration }}" }}) — the standby is falling behind; RPO on a hard primary failure is widening.'
+        # CNPG flags when it cannot complete a switchover automatically and needs
+        # operator intervention (e.g. primary pinned to a node that must drain).
+        - alert: CnpgManualSwitchoverRequired
+          expr: cnpg_collector_manual_switchover_required > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: 'CNPG manual switchover required in {{ "{{ $labels.namespace }}" }}'
+            description: 'CNPG signalled manual_switchover_required on {{ "{{ $labels.pod }}" }} — the operator cannot resolve a switchover on its own. Investigate before draining that node.'
+        # The CNPG scrape pipeline must not go dark silently (the 16-day outage
+        # stayed invisible because monitoring was blind). If every cnpg_* series
+        # disappears, the PodMonitor/NetworkPolicy/scrape path has broken.
+        - alert: CnpgMetricsAbsent
+          expr: absent(cnpg_collector_up)
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: 'CNPG metrics are absent — databases are UNMONITORED'
+            description: 'No cnpg_collector_up series for 15m. The CNPG PodMonitor scrape path (apps/*/infra/podmonitor.yaml, networkpolicy-db.yaml monitoring:9187 ingress, allow-prometheus-scraping egress) may have broken — DB alerting is blind.'


### PR DESCRIPTION
## Why
Step 2 of architecture-plan **D.1**. With CNPG metrics now scraped (#144), the HA Postgres clusters (`hearthly-db`, `keycloak-db`) still had **zero alerting**. A single-instance DB *caused* the 2026-05 outage (#131) — these rules make the database fail loud.

## Rules (all grounded in metrics verified live on both clusters)
| Alert | Expr | Sev | Why |
|---|---|---|---|
| `CnpgInstanceDown` | `cnpg_collector_up == 0` (5m) | critical | Instance unreachable/unhealthy |
| `CnpgHAReplicaMissing` | `max by(namespace)(cnpg_pg_replication_streaming_replicas) < 1` (5m) | critical | **Primary has no streaming standby = HA silently degraded toward single-instance — the exact 2026-05 outage condition.** Highest-value rule. |
| `CnpgReplicationLagHigh` | `cnpg_pg_replication_lag > 30` (10m) | warning | Async standby falling behind; RPO widening |
| `CnpgManualSwitchoverRequired` | `cnpg_collector_manual_switchover_required > 0` (5m) | warning | CNPG can't auto-resolve a switchover |
| `CnpgMetricsAbsent` | `absent(cnpg_collector_up)` (15m) | warning | Fail-loud guard — the DB scrape pipeline must not go dark silently (the core outage lesson) |

## Deliberately deferred to D.6 (Barman backups)
- **Backup-age** alert: `cnpg_collector_last_available_backup_timestamp` is `0` (we use pg_dump, not CNPG/Barman) → a backup-age alert would false-fire. pg_dump failures are already covered by `prometheusrule-backup-failures.yaml`.
- **WAL-archive-failure** alert: WAL archiving isn't configured yet (the plan's guessed metric name doesn't even exist in this CNPG version; the real `cnpg_pg_stat_archiver_*` series only become meaningful once continuous archiving is on).

## Verification
- Every metric was confirmed present + its semantics checked against live data (e.g. `streaming_replicas` is reported per-pod; the primary's value = # streaming standbys, hence `max by(namespace)`).
- Rendered rule passes the prometheus-operator **admission webhook** (PromQL syntax validated) via `kubectl apply --dry-run=server`.
- Prettier clean.
- Post-merge: will confirm the `cnpg` rule group loads in Prometheus and no rule false-fires on the healthy clusters.

Refs #131