### PR TITLE
infra(storage): declarative Retain StorageClass for DB volumes

### DIFF
--- a/apps/hearthly-api/infra/database.yaml
+++ b/apps/hearthly-api/infra/database.yaml
@@ -20,7 +20,10 @@ spec:
 
   storage:
     size: 10Gi
-    storageClass: hcloud-volumes
+    # Retain on accidental PVC/Cluster deletion (see storageclasses/). Applies to
+    # volumes provisioned from here on; existing PVs keep their reclaim policy and
+    # were patched to Retain out-of-band (audit note in infrastructure/CLAUDE.md).
+    storageClass: hcloud-volumes-retain
 
   resources:
     requests:

--- a/infrastructure/CLAUDE.md
+++ b/infrastructure/CLAUDE.md
@@ -66,7 +66,7 @@ All external traffic routes through Kubernetes Gateway API (HTTPRoute).
 - **Operator:** CloudNativePG v1.28.1 (namespace: cnpg-system)
 - **hearthly-db:** hearthly namespace, 10Gi. `DATABASE_URL` from K8s Secret `hearthly-db-app`. Backups: daily pg_dump at 02:00 UTC → `hearthly-backups` S3 bucket.
 - **keycloak-db:** keycloak namespace, 5Gi. Credentials in K8s Secret `keycloak-db-app`. Backups: daily at 03:00 UTC → same bucket, prefix `keycloak-db-`.
-- **PV reclaim:** Retain on both (patched manually).
+- **PV reclaim:** Both CNPG clusters use the **`hcloud-volumes-retain`** StorageClass (`reclaimPolicy: Retain`, declarative in `cluster-services/storageclasses/`, its own ArgoCD app). This governs **newly provisioned** volumes only. The 4 existing DB PVs (hearthly-db-1/2, keycloak-db-1/2) keep their reclaim policy from creation and were patched to `Retain` out-of-band — **audit note:** the original manual patch (2026-05) covered only the primaries (db-1); the Phase A HA standbys (db-2) were on `Delete` until patched to `Retain` on 2026-05-30 (architecture plan D.5). Existing dynamically-provisioned PVs cannot be GitOps-managed; verify with `kubectl get pv -o custom-columns=NAME:.metadata.name,CLAIM:.spec.claimRef.name,RECLAIM:.spec.persistentVolumeReclaimPolicy`.
 
 ## Alerting & Monitoring
 

--- a/infrastructure/cluster-services/argocd/applications/storageclasses.yaml
+++ b/infrastructure/cluster-services/argocd/applications/storageclasses.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: storageclasses
+  namespace: argocd
+  # Sync before stateful consumers so the Retain StorageClass exists before any
+  # CNPG cluster provisions a volume against it (cold bootstrap).
+  annotations:
+    argocd.argoproj.io/sync-wave: '-2'
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/rudingma/hearthly.git
+    targetRevision: main
+    path: infrastructure/cluster-services/storageclasses
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system # StorageClass is cluster-scoped; namespace is ignored
+  syncPolicy:
+    automated:
+      # prune INTENTIONALLY false: a StorageClass referenced by bound PVs must
+      # not be auto-deleted (it would orphan provisioning + block expansion).
+      # Removal must be deliberate.
+      prune: false
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false

--- a/infrastructure/cluster-services/keycloak/infra/database.yaml
+++ b/infrastructure/cluster-services/keycloak/infra/database.yaml
@@ -18,7 +18,10 @@ spec:
 
   storage:
     size: 5Gi
-    storageClass: hcloud-volumes
+    # Retain on accidental PVC/Cluster deletion (see storageclasses/). Applies to
+    # volumes provisioned from here on; existing PVs keep their reclaim policy and
+    # were patched to Retain out-of-band (audit note in infrastructure/CLAUDE.md).
+    storageClass: hcloud-volumes-retain
 
   resources:
     requests:

--- a/infrastructure/cluster-services/storageclasses/hcloud-volumes-retain.yaml
+++ b/infrastructure/cluster-services/storageclasses/hcloud-volumes-retain.yaml
@@ -1,0 +1,20 @@
+# Retain variant of the default hcloud-volumes StorageClass, for stateful data
+# that must survive accidental PVC/Cluster deletion (PostgreSQL).
+#
+# The kube-hetzner module's default `hcloud-volumes` is reclaimPolicy: Delete —
+# so deleting a PVC (or `kubectl delete cluster`) destroys the underlying Hetzner
+# volume and its data. DB volumes point here instead (see the CNPG Cluster specs)
+# so retention is DECLARATIVE and in Git, rather than a manual `kubectl patch` on
+# each PV (the manual patch was applied unevenly — the Phase A HA standbys were
+# missed). Backups (D.6 Barman) remain the recovery mechanism; Retain is the
+# accidental-deletion safety net. See issue #131, architecture plan D.5.
+#
+# Identical to hcloud-volumes except reclaimPolicy and NOT the default class.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: hcloud-volumes-retain
+provisioner: csi.hetzner.cloud
+reclaimPolicy: Retain
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true


### PR DESCRIPTION
## Why
Architecture-plan **D.5**. DB volume retention was a manual `kubectl patch` per PV — and an audit during this task found it was applied **unevenly**: the Phase A HA standbys (`hearthly-db-2`, `keycloak-db-2`) were still on `reclaimPolicy: Delete` while the primaries were `Retain`. That's a latent data-loss gap *and* the same 'manual config, not in Git, applied inconsistently' class that caused the 2026-05 outage (#131).

## What
- **New `hcloud-volumes-retain` StorageClass** (`reclaimPolicy: Retain`, else identical to the default `hcloud-volumes`) — declarative in `cluster-services/storageclasses/` with its own ArgoCD app (sync-wave `-2`; `prune: false` so a StorageClass backing bound PVs is never auto-deleted).
- **Repointed both CNPG specs** at it. Per CNPG docs, `storageClass` changes affect only **newly provisioned** volumes — existing PVCs are immutable and untouched, so **no churn on the live DBs** (verified: webhook accepts the change; re-creation would require a manual `delete pvc/pod`, which we are not doing).
- **Existing PVs** can't be GitOps-managed (dynamically provisioned). The 2 standby PVs were patched `Delete → Retain` out-of-band — **all 4 DB PVs are now Retain** — with an audit note added to `infrastructure/CLAUDE.md`.

## Scope / non-goals
- Existing volumes are **not** migrated onto the new SC (that needs a backup/restore — out of scope; D.6).
- Monitoring PVs (grafana/prometheus/alertmanager) intentionally stay on the default Delete SC — that data is reproducible (dashboards are in Git as ConfigMaps; metrics are short-retention).
- Retain is the *accidental-deletion safety net*; **backups (D.6 Barman) remain the recovery mechanism**.

## Verification
- StorageClass, ArgoCD Application, and both repointed CNPG specs all pass `kubectl apply --dry-run=server`.
- All 4 DB PVs confirmed `Retain` live.
- Prettier clean.

Refs #131