### PR TITLE
infra(csi): system-cluster-critical priority for hcloud-csi

### DIFF
--- a/infrastructure/cluster/main.tf
+++ b/infrastructure/cluster/main.tf
@@ -101,6 +101,33 @@ module "kube-hetzner" {
   hetzner_csi_version = "v2.20.0"
   kured_version       = "1.21.0"
 
+  # Give the CSI driver system-cluster-critical priority so kubelet evicts it
+  # LAST under node pressure. During the 2026-05 outage the CSI node plugin was
+  # evicted -> the driver deregistered from kubelet -> PVs could not attach
+  # (issue #131). controller (provisioning) and node (attach/mount) both matter.
+  # NOTE: setting hetzner_csi_values REPLACES the module default (locals.tf, which
+  # is ONLY the node affinity), so the control-plane + robot exclusion is
+  # replicated here verbatim (we do not schedule on the control plane). Chart
+  # v2.20.0 exposes controller.priorityClassName + node.priorityClassName.
+  # Architecture plan C.2.
+  hetzner_csi_values = <<-EOT
+controller:
+  priorityClassName: system-cluster-critical
+node:
+  priorityClassName: system-cluster-critical
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: "node-role.kubernetes.io/control-plane"
+                operator: DoesNotExist
+              - key: "instance.hetzner.cloud/provided-by"
+                operator: NotIn
+                values:
+                  - robot
+EOT
+
   # Gateway API: enable Traefik's kubernetesGateway provider.
   # CRDs are owned explicitly by the gateway-api-crds ArgoCD app (the v40 chart
   # no longer bundles them); cert-manager Gateway API support is enabled


### PR DESCRIPTION
## Why
Architecture-plan **C.2**. During the 2026-05 outage the CSI node plugin was evicted under node pressure → the driver deregistered from kubelet → **PVs could not attach**. The C.2 spike found the CSI controller + node DaemonSet at **priority 0** (CoreDNS already had `system-cluster-critical`). PriorityClasses make kubelet evict the CSI driver **last**.

## What
Set `controller.priorityClassName` + `node.priorityClassName = system-cluster-critical` via the module's `hetzner_csi_values`.

**Mechanism note (important):** setting `hetzner_csi_values` *replaces* the module's default value, which is **only** a node-affinity block. So the control-plane + robot node-affinity exclusion is **replicated verbatim** (we don't schedule on the control plane — `allow_scheduling_on_control_plane` unset; matches the current 3 worker-only `csi-node` pods). Chart v2.20.0 exposes both `priorityClassName` keys (verified via `helm show values`).

## Scope notes
- **kured** left as-is — no module knob for its `priorityClassName` (`kured_options` is CLI flags only), and it's the lowest-criticality of the three (an evicted kured only delays a reboot cycle).
- **CNPG** priority is separate (not in plan C.2; would force a DB rolling restart).

## Hard-gate: local `terraform plan` is clean
`Plan: 3 to add, 0 to change, 2 to destroy`:
- `hcloud_ssh_key` replace — known-benign provider drift (`hcloud_server` ignores `ssh_keys`, **no node recreate**, self-heals).
- `terraform_data.kustomization` replace — re-applies the addons carrying the CSI values (same mechanism as the #140 Traefik pin).
- `local_file.kustomization_backup` create — local backup.
- **No `hcloud_server` / load_balancer / network / volume changes.**

CI's terraform-plan comment is the official gate — confirm it matches the above before merge. (Also pressure-tested with a Codex adversarial review.)

Refs #131