### PR TITLE
feat(monitoring): external-deadman heartbeat + ntfy topic rename

### DIFF
--- a/infrastructure/cluster-services/monitoring/templates/cronjob-deadman-heartbeat.yaml
+++ b/infrastructure/cluster-services/monitoring/templates/cronjob-deadman-heartbeat.yaml
@@ -1,0 +1,90 @@
+# External deadman heartbeat (architecture plan D.2).
+#
+# Every 5 minutes this job confirms the in-cluster alerting pipeline is actually
+# ALIVE — by checking that Alertmanager still holds the always-firing `Watchdog`
+# alert (which only exists if Prometheus is up and evaluating rules AND
+# Alertmanager received it) — and ONLY THEN publishes a heartbeat to a dedicated,
+# unguessable ntfy topic. The external GitHub healthcheck polls that topic; if no
+# heartbeat arrives, in-cluster monitoring has gone dark (the 2026-05 outage stayed
+# invisible for 16 days precisely because monitoring was silent). See issue #131.
+#
+# Deliberately ADDITIVE — it does NOT touch the live Alertmanager/ntfy alerting
+# path, so a bug here can never suppress real alerts. If the heartbeat is missing,
+# that is the signal (detected externally); the job itself exits 0 either way.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: deadman-heartbeat
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: deadman-heartbeat
+spec:
+  schedule: '*/5 * * * *'
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 120
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      # Don't pile up retries on the disk-constrained nodes; one attempt per tick.
+      backoffLimit: 0
+      activeDeadlineSeconds: 60
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: deadman-heartbeat
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: heartbeat
+              image: curlimages/curl:8.11.1
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ['ALL']
+              env:
+                - name: DEADMAN_TOPIC
+                  valueFrom:
+                    secretKeyRef:
+                      name: ntfy-topic
+                      key: deadman-topic
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -u
+                  # Scope to the Watchdog alert; grep on the bare name is immune
+                  # to the API's JSON whitespace. If Alertmanager is down, curl -f
+                  # fails -> no match -> heartbeat withheld -> deadman fires.
+                  AM='http://monitoring-kube-prometheus-alertmanager:9093/api/v2/alerts?active=true&filter=alertname%3DWatchdog'
+                  if curl -sf --max-time 10 "$AM" | grep -q 'Watchdog'; then
+                    if curl -sf --max-time 10 \
+                         -H 'Title: hearthly-deadman' \
+                         -H 'Priority: min' \
+                         -H 'Tags: heartbeat' \
+                         -d 'in-cluster monitoring pipeline alive (Watchdog active)' \
+                         "https://ntfy.sh/${DEADMAN_TOPIC}" >/dev/null; then
+                      echo "heartbeat published"
+                    else
+                      echo "WARN: heartbeat publish to ntfy failed (egress/ntfy issue)"
+                    fi
+                  else
+                    echo "Watchdog NOT active in Alertmanager — withholding heartbeat (deadman will fire externally)"
+                  fi
+                  exit 0
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 16Mi
+                limits:
+                  cpu: 50m
+                  memory: 32Mi

--- a/infrastructure/cluster-services/monitoring/templates/infisical-ntfy-secret.yaml
+++ b/infrastructure/cluster-services/monitoring/templates/infisical-ntfy-secret.yaml
@@ -21,5 +21,14 @@ spec:
     creationPolicy: Orphan
     template:
       data:
+        # Cluster Alertmanager alerts topic. Renamed from NTFY_TOPIC ->
+        # NTFY_ALERTS_TOPIC for clarity now that there are multiple ntfy topics
+        # (alerts vs deadman heartbeat). See issue #131 / plan D.2.
         topic.yml: |-
-          {{ `{{ printf "ntfy:\n  notification:\n    topic: %s" .NTFY_TOPIC.Value }}` }}
+          {{ `{{ printf "ntfy:\n  notification:\n    topic: %s" .NTFY_ALERTS_TOPIC.Value }}` }}
+        # Deadman heartbeat topic (raw value), consumed by the deadman-heartbeat
+        # CronJob. A dedicated, unguessable topic that the external GitHub
+        # healthcheck polls; absence of recent messages => in-cluster monitoring
+        # is dark (the 16-day-silent failure class). See issue #131 / plan D.2.
+        deadman-topic: |-
+          {{ `{{ .NTFY_DEADMAN_TOPIC.Value }}` }}

--- a/infrastructure/network-policies/templates/monitoring.yaml
+++ b/infrastructure/network-policies/templates/monitoring.yaml
@@ -283,3 +283,45 @@ spec:
       ports:
         - port: 443
           protocol: TCP
+---
+# Deadman heartbeat CronJob (D.2): egress to DNS + ntfy.sh (publish heartbeat).
+# Its query to in-cluster Alertmanager (:9093) is intra-namespace and already
+# covered by allow-monitoring-intra-namespace. See issue #131.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-deadman-egress
+  namespace: monitoring
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: deadman-heartbeat
+  policyTypes:
+    - Egress
+  egress:
+    # DNS resolution (ntfy.sh + the in-cluster Alertmanager service name)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # External HTTPS — publish the heartbeat to ntfy.sh
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - port: 443
+          protocol: TCP


### PR DESCRIPTION
## Why
Architecture-plan **D.2** (cluster side). The 2026-05 outage stayed invisible for 16 days partly because in-cluster monitoring was silent. A deadman detects that class of failure — the cluster keeps emitting a heartbeat, and an external checker alarms on its **absence**.

## What
- **`deadman-heartbeat` CronJob** (every 5m): confirms the pipeline is alive by checking Alertmanager still holds the always-firing `Watchdog` alert (⇒ Prometheus is evaluating *and* Alertmanager received it), and only then publishes a heartbeat to a dedicated, unguessable ntfy topic. **Additive** — it never touches the live Alertmanager/ntfy path, so it cannot suppress real alerts. If the pipeline looks dead it withholds the heartbeat (exits 0); that absence is the signal. Pinned image, non-root, drop-ALL, read-only rootfs, no SA token, tiny job-history limits (kind to the disk-tight nodes).
- **ntfy topic rename** (clarity, now that there are 2+ topics): the InfisicalSecret sources the alerts topic from `NTFY_ALERTS_TOPIC` (was `NTFY_TOPIC`) and additionally exposes `deadman-topic` (`NTFY_DEADMAN_TOPIC`) to the CronJob. **`topic.yml` content is unchanged** (`NTFY_ALERTS_TOPIC` == old value), so the alertmanager-ntfy sidecar is unaffected.
- **`allow-deadman-egress` NetworkPolicy**: DNS + ntfy.sh:443 for the heartbeat pod (its Alertmanager query is intra-namespace, already covered). Mirrors the proven blackbox egress.

## Notes
- Topic values live only in Infisical / GitHub Secrets (the repo is public).
- The external poll side (healthcheck workflow alarms on missing heartbeat) is a **second PR**, once the GitHub `NTFY_DEADMAN_TOPIC` secret is set.
- Safe rename sequence: `NTFY_ALERTS_TOPIC` already added in Infisical (same value); after this merges + the `ntfy-topic` secret re-syncs cleanly, the old `NTFY_TOPIC` gets deleted.

## Verification
- helm template (both charts) + `kubectl apply --dry-run=server`: CronJob/NetworkPolicy `created`, InfisicalSecret `configured`.
- Prettier clean.
- Post-merge: confirm the CronJob logs `heartbeat published`, the `ntfy-topic` secret still renders the correct alerts `topic.yml`, and real alerting is unaffected.

Refs #131