### PR TITLE
fix(network-policies): deadman heartbeat egress to Alertmanager (namespaceSelector)

### DIFF
--- a/infrastructure/network-policies/templates/monitoring.yaml
+++ b/infrastructure/network-policies/templates/monitoring.yaml
@@ -284,9 +284,14 @@ spec:
         - port: 443
           protocol: TCP
 ---
-# Deadman heartbeat CronJob (D.2): egress to DNS + ntfy.sh (publish heartbeat).
-# Its query to in-cluster Alertmanager (:9093) is intra-namespace and already
-# covered by allow-monitoring-intra-namespace. See issue #131.
+# Deadman heartbeat CronJob (D.2): egress to DNS + in-cluster Alertmanager
+# (:9093, to confirm Watchdog is firing) + ntfy.sh (publish heartbeat).
+# NOTE: the Alertmanager hop MUST be allowed via namespaceSelector, not relied
+# upon from allow-monitoring-intra-namespace's `podSelector: {}` — under
+# kube-router that podSelector egress does NOT actually reach the Alertmanager
+# pod (verified: even a plain monitoring pod gets connection-refused/timeout).
+# Prometheus reaches Alertmanager the same way (allow-prometheus-scraping uses a
+# namespaceSelector). See issue #131.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -313,6 +318,15 @@ spec:
         - port: 53
           protocol: UDP
         - port: 53
+          protocol: TCP
+    # In-cluster Alertmanager API (read the active Watchdog alert). Must be a
+    # namespaceSelector (podSelector {} is ineffective under kube-router here).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: 9093
           protocol: TCP
     # External HTTPS — publish the heartbeat to ntfy.sh
     - to:


### PR DESCRIPTION
Follow-up to #148. The `deadman-heartbeat` CronJob was **withholding** its heartbeat — it couldn't reach the Alertmanager API to confirm `Watchdog`.

**Root cause:** `allow-monitoring-intra-namespace`'s `podSelector: {}` egress does **not** actually reach the Alertmanager pod under kube-router. Verified live: even a plain monitoring pod (no deadman label) gets a connection timeout to `alertmanager:9093` via that rule. Prometheus reaches Alertmanager via a **namespaceSelector** (`allow-prometheus-scraping`) — that's the pattern that works here.

**Fix:** add a scoped `namespaceSelector(monitoring)` egress rule on `:9093` to `allow-deadman-egress`. Verified live with a temporary policy — both the ClusterIP and headless Alertmanager services return 200 and match `Watchdog`.

(Latent note: `allow-monitoring-intra-namespace`'s podSelector egress is broadly ineffective under kube-router; intra-namespace initiators rely on namespaceSelector. Out of scope to fix globally here.)

Refs #131