### PR TITLE
feat(healthcheck): external deadman — alarm if in-cluster monitoring goes silent

### DIFF
--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -15,6 +15,11 @@ jobs:
       - name: Check production endpoints
         env:
           NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
+          # External deadman (D.2): the in-cluster deadman-heartbeat CronJob
+          # publishes here every 5m while monitoring is alive; we alarm on its
+          # ABSENCE. Optional — if unset, the deadman check is skipped (endpoint
+          # checks still run), so this is safe to merge before the secret exists.
+          NTFY_DEADMAN_TOPIC: ${{ secrets.NTFY_DEADMAN_TOPIC }}
         run: |
           if [ -z "$NTFY_TOPIC" ]; then
             echo "::error::NTFY_TOPIC secret is not set"
@@ -41,6 +46,8 @@ jobs:
           check_endpoint "https://argocd.hearthly.dev/" "200"
           check_endpoint "https://secrets.hearthly.dev/" "200"
 
+          RC=0
+
           if [ -n "$FAILED" ]; then
             MESSAGE="Production endpoints DOWN:${NL}${FAILED}"
             curl -s \
@@ -50,7 +57,33 @@ jobs:
               -d "$MESSAGE" \
               "https://ntfy.sh/${NTFY_TOPIC}"
             echo "::error::Endpoints failed: ${FAILED}"
-            exit 1
+            RC=1
+          else
+            echo "All endpoints healthy"
           fi
 
-          echo "All endpoints healthy"
+          # External deadman: the in-cluster deadman-heartbeat CronJob publishes
+          # to NTFY_DEADMAN_TOPIC every 5m ONLY while the Prometheus->Alertmanager
+          # pipeline is alive (Watchdog active). If no heartbeat landed in the last
+          # 15m, in-cluster monitoring has gone dark — alerts could be SILENT, the
+          # failure mode that hid the 2026-05 outage for 16 days. This check is
+          # independent of the cluster (runs in GitHub Actions). See issue #131.
+          if [ -n "$NTFY_DEADMAN_TOPIC" ]; then
+            HB=$(curl -s --max-time 15 "https://ntfy.sh/${NTFY_DEADMAN_TOPIC}/json?poll=1&since=15m" 2>/dev/null || echo "")
+            if echo "$HB" | grep -q heartbeat; then
+              echo "Deadman: in-cluster monitoring heartbeat present"
+            else
+              curl -s \
+                -H "Title: Hearthly: monitoring deadman" \
+                -H "Priority: urgent" \
+                -H "Tags: skull" \
+                -d "In-cluster monitoring is DARK: no deadman heartbeat in 15m. Prometheus/Alertmanager may be down and cluster alerts could be SILENT. Investigate the monitoring stack." \
+                "https://ntfy.sh/${NTFY_TOPIC}"
+              echo "::error::Deadman: no in-cluster heartbeat in the last 15m"
+              RC=1
+            fi
+          else
+            echo "::warning::NTFY_DEADMAN_TOPIC not set — skipping deadman check (set the GitHub secret to enable it)"
+          fi
+
+          exit $RC


### PR DESCRIPTION
Completes architecture-plan **D.2** (external side). Pairs with #148/#149/#150 (the cluster heartbeat, now verified publishing).

The GitHub healthcheck — independent of the cluster, every 5m — now also polls `NTFY_DEADMAN_TOPIC`. The in-cluster `deadman-heartbeat` CronJob publishes there **only while the Prometheus→Alertmanager pipeline is alive** (Watchdog active). **No heartbeat in 15m ⇒ in-cluster monitoring is dark and cluster alerts could be SILENT** — the exact failure mode that hid the 2026-05 outage for 16 days ⇒ urgent ntfy alert via the existing topic.

**Graceful:** if `NTFY_DEADMAN_TOPIC` is unset, the deadman check is skipped (endpoint checks still run) — safe to merge before the GitHub secret is set; it activates automatically once the secret exists.

## Verification
- Prettier clean; `bash -n` on the embedded script passes.
- Cluster heartbeat already verified publishing (manual job → `heartbeat published`).
- Activation: set the GitHub secret `NTFY_DEADMAN_TOPIC` (same value as Infisical), then a manual `workflow_dispatch` run should log `Deadman: in-cluster monitoring heartbeat present`.

Refs #131