### PR TITLE
feat(api): deep DB-backed healthcheck /health/deep (#131)

### DIFF
--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -41,6 +41,10 @@ jobs:
 
           check_endpoint "https://hearthly.dev/" "200"
           check_endpoint "https://api.hearthly.dev/health" "200"
+          # Deep, DB-backed readiness (C.6): /health is shallow (process-alive
+          # only), so a DB outage would not surface there. /health/deep runs a
+          # SELECT 1 and returns 503 if the DB is unreachable.
+          check_endpoint "https://api.hearthly.dev/health/deep" "200"
           check_endpoint "https://auth.hearthly.dev/" "302"
           check_endpoint "https://grafana.hearthly.dev/" "302"
           check_endpoint "https://argocd.hearthly.dev/" "200"

--- a/apps/hearthly-api/src/app/app.module.ts
+++ b/apps/hearthly-api/src/app/app.module.ts
@@ -19,6 +19,7 @@ import { UserModule } from '../modules/user/user.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { HealthController } from './health.controller';
+import { DeepHealthController } from './deep-health.controller';
 
 const gqlLogger = new Logger('GraphQLSecurity');
 
@@ -74,7 +75,7 @@ const gqlLogger = new Logger('GraphQLSecurity');
     UserModule,
     HouseholdModule,
   ],
-  controllers: [AppController, HealthController],
+  controllers: [AppController, HealthController, DeepHealthController],
   providers: [
     AppService,
     {

--- a/apps/hearthly-api/src/app/deep-health.controller.spec.ts
+++ b/apps/hearthly-api/src/app/deep-health.controller.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import type { TransactionHost } from '@nestjs-cls/transactional';
+import type { TransactionalAdapterDrizzleOrm } from '@nestjs-cls/transactional-adapter-drizzle-orm';
+import { createTestDb, TestDb } from '../../test/support/test-db';
+import type { DrizzleDB } from '../database';
+import { DeepHealthController } from './deep-health.controller';
+
+// The controller only needs `txHost.tx` to run `SELECT 1`, so we construct it
+// directly with a minimal TransactionHost stub — the happy path wraps a real
+// PGlite db (proving the query actually reaches a database), the failure path
+// uses a stub whose `execute` rejects. Mirrors the createMockTxHost pattern in
+// household.service.integration.spec.ts.
+type StubTxHost = TransactionHost<TransactionalAdapterDrizzleOrm<DrizzleDB>>;
+
+describe('DeepHealthController', () => {
+  let db: TestDb;
+
+  beforeAll(async () => {
+    db = await createTestDb();
+  });
+
+  it('responds 200 {status:ok} when the DB is reachable', async () => {
+    const controller = new DeepHealthController({
+      tx: db,
+    } as unknown as StubTxHost);
+
+    await expect(controller.deep()).resolves.toEqual({ status: 'ok' });
+  });
+
+  it('responds 503 when the DB query throws', async () => {
+    const txHost = {
+      tx: {
+        execute: () => Promise.reject(new Error('connection refused')),
+      },
+    } as unknown as StubTxHost;
+    const controller = new DeepHealthController(txHost);
+
+    let caught: unknown;
+    try {
+      await controller.deep();
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(HttpException);
+    expect((caught as HttpException).getStatus()).toBe(
+      HttpStatus.SERVICE_UNAVAILABLE
+    );
+  });
+});

--- a/apps/hearthly-api/src/app/deep-health.controller.ts
+++ b/apps/hearthly-api/src/app/deep-health.controller.ts
@@ -1,0 +1,39 @@
+import { Controller, Get, HttpException, HttpStatus } from '@nestjs/common';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterDrizzleOrm } from '@nestjs-cls/transactional-adapter-drizzle-orm';
+import { sql } from 'drizzle-orm';
+import type { DrizzleDB } from '../database';
+import { Public } from '../modules/auth';
+
+/**
+ * Deep, DB-backed readiness check — deliberately separate from the shallow
+ * `/health` liveness probe (which stays process-alive only, see
+ * health.controller.ts). This runs `SELECT 1` through the same Drizzle/CLS
+ * path real queries use, so the external GitHub healthcheck can detect a DB
+ * outage that the liveness probe is designed to hide. Returns 200
+ * `{status:'ok'}` when the DB answers, 503 otherwise.
+ *
+ * Architecture plan Task C.6 (issue #131).
+ */
+@Public()
+@Controller('health')
+export class DeepHealthController {
+  constructor(
+    private readonly txHost: TransactionHost<
+      TransactionalAdapterDrizzleOrm<DrizzleDB>
+    >
+  ) {}
+
+  @Get('deep')
+  async deep(): Promise<{ status: string }> {
+    try {
+      await this.txHost.tx.execute(sql`SELECT 1`);
+      return { status: 'ok' };
+    } catch {
+      throw new HttpException(
+        { status: 'error' },
+        HttpStatus.SERVICE_UNAVAILABLE
+      );
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds `GET /health/deep` to hearthly-api — a deep, DB-backed readiness check that runs `SELECT 1` through the same Drizzle/CLS path real queries use. Returns `200 {status:'ok'}` when the DB answers, `503` otherwise. `@Public()`.

The existing `/health` probe stays shallow (process-alive only, by design — it's the liveness probe). A DB outage therefore never surfaces on `/health`, which is exactly the blind spot we want the external monitor to catch. The GitHub `healthcheck.yml` workflow now probes `/health/deep` alongside the other endpoints.

## Why

Architecture plan **Task C.6** (issue #131): keep liveness shallow, make a separate endpoint represent DB-backed readiness, and have the external workflow probe that. Complements the external deadman (D.2) — deadman catches "monitoring is dark", this catches "API is up but its DB is gone".

## Changes

- `apps/hearthly-api/src/app/deep-health.controller.ts` (new) — `@Public() @Controller('health')` → `@Get('deep')`
- `apps/hearthly-api/src/app/deep-health.controller.spec.ts` (new) — 200 via PGlite, 503 on a throwing tx stub
- `apps/hearthly-api/src/app/app.module.ts` — register the controller
- `.github/workflows/healthcheck.yml` — `check_endpoint .../health/deep 200`

## Verification

- `nx test hearthly-api` — 51 tests pass (incl. the 2 new)
- `nx lint hearthly-api` — 0 errors
- `nx build hearthly-api` — webpack OK
- `prettier --check` — clean

Unblocks D.4 (deploy-verify uses `/health/deep` as its smoke test).

Closes part of #131.