### PR TITLE
fix(monitoring): raise node-exporter CPU limit 100m->200m (CPUThrottlingHigh) (#131)

### DIFF
--- a/infrastructure/cluster-services/monitoring/values.yaml
+++ b/infrastructure/cluster-services/monitoring/values.yaml
@@ -280,13 +280,21 @@ kube-prometheus-stack:
         memory: 128Mi
 
   # --- Node exporter (runs on every node) ---
+  # --- node-exporter ---
+  # CPU limit raised 100m->200m: node-exporter briefly bursts above 100m while
+  # all collectors run during a scrape, throttling >25% of CFS periods and
+  # firing CPUThrottlingHigh (info). At a 100m limit the container gets only
+  # 10ms of CPU per 100ms period; nodes have ample CPU headroom, so the
+  # container limit — not the node — was the bottleneck. Same CFS-throttle root
+  # cause as the kube-state-metrics fix below (#143). Memory left at 64Mi
+  # (node-exporter's RSS is steady, no throttling/OOM pressure there).
   prometheus-node-exporter:
     resources:
       requests:
         cpu: 20m
         memory: 32Mi
       limits:
-        cpu: 100m
+        cpu: 200m
         memory: 64Mi
 
   # --- kube-state-metrics ---


### PR DESCRIPTION
## What

Raises the `prometheus-node-exporter` CPU limit from **100m → 200m** in the monitoring stack values.

## Why

`CPUThrottlingHigh` (info) has been firing for the `node-exporter` container. At a 100m limit the container gets only 10ms of CPU per 100ms CFS period; node-exporter briefly bursts above that while all collectors run during a scrape, so >25% of CFS periods were throttled — which is exactly what `CPUThrottlingHigh` measures. The nodes have ample CPU headroom, so the container limit (not the node) was the bottleneck.

Same CFS-throttle root cause as the kube-state-metrics fix (#143); memory is left at 64Mi (node-exporter's RSS is steady, no throttling/OOM pressure there).

## Verification

- `helm template monitoring infrastructure/cluster-services/monitoring` renders OK; the node-exporter DaemonSet container shows `limits.cpu: 200m`.
- `prettier --check` clean.

Architecture plan follow-up. Part of #131.