### PR TITLE
feat(deploy): verify ArgoCD synced the deployed revision + smoke test (D.4) (#131)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -205,6 +205,10 @@ jobs:
     needs: [changes, build-api, build-app, build-keycloak]
     if: always() && (needs.build-api.result == 'success' || needs.build-app.result == 'success' || needs.build-keycloak.result == 'success')
     runs-on: ubuntu-latest
+    # Expose the commit SHA pushed (empty if no tag changed) so `verify` can
+    # assert ArgoCD actually synced THIS revision, not a stale one (D.4).
+    outputs:
+      commit_sha: ${{ steps.commit.outputs.sha }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -226,14 +230,63 @@ jobs:
           fi
 
       - name: Commit and push
+        id: commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add apps/*/deploy/chart/values.yaml infrastructure/cluster-services/keycloak/values.yaml
-          git diff --cached --quiet && exit 0
+          if git diff --cached --quiet; then
+            echo "sha=" >> "$GITHUB_OUTPUT"   # nothing deployed -> verify skips
+            exit 0
+          fi
           git commit -m "deploy: update image tags to ${{ github.sha }}"
           for i in 1 2 3; do
             git push && break
             echo "Push failed, retrying after rebase..."
             git pull --rebase origin main
           done
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  # Verify ArgoCD actually deployed the revision we just pushed, then smoke-test.
+  # Gated on ARGOCD_TOKEN: safe to merge before the read-only token secret is
+  # set — the job no-ops with a warning until then (same pattern as the deadman
+  # check in healthcheck.yml). See PR / infrastructure/cluster/BOOTSTRAP.md. (D.4)
+  verify:
+    needs: [changes, build-api, build-app, build-keycloak, update-tags]
+    if: always() && needs.update-tags.result == 'success' && needs.update-tags.outputs.commit_sha != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for ArgoCD to sync THIS revision + smoke test
+        env:
+          ARGOCD_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+          WANT_SHA: ${{ needs.update-tags.outputs.commit_sha }}
+        run: |
+          if [ -z "$ARGOCD_TOKEN" ]; then
+            echo "::warning::ARGOCD_TOKEN not set — skipping ArgoCD revision verification (set the GitHub secret to enable it)"
+            exit 0
+          fi
+
+          apps=()
+          [ "${{ needs.changes.outputs.api }}" = "true" ] && [ "${{ needs.build-api.result }}" = "success" ] && apps+=("hearthly-api")
+          [ "${{ needs.changes.outputs.app }}" = "true" ] && [ "${{ needs.build-app.result }}" = "success" ] && apps+=("hearthly-app")
+          [ "${{ needs.build-keycloak.result }}" = "success" ] && apps+=("keycloak")
+
+          # ArgoCD tracks the repo revision, so each app's status.sync.revision
+          # should converge to the commit update-tags just pushed. Exact match
+          # assumes no newer commit lands on main before Argo syncs this one —
+          # the normal case (deploys serialize; update-tags rebases onto HEAD).
+          for app in "${apps[@]}"; do
+            for i in $(seq 1 30); do
+              json=$(curl -fsSL -H "Authorization: Bearer $ARGOCD_TOKEN" \
+                     "https://argocd.hearthly.dev/api/v1/applications/$app")
+              s=$(echo "$json" | jq -r '"\(.status.sync.status)/\(.status.health.status)"')
+              rev=$(echo "$json" | jq -r '.status.sync.revision')
+              echo "[$i] $app: $s @ ${rev:0:7} (want ${WANT_SHA:0:7})"
+              if [ "$s" = "Synced/Healthy" ] && [ "$rev" = "$WANT_SHA" ]; then break; fi
+              [ "$i" = "30" ] && { echo "::error::$app not Synced/Healthy at $WANT_SHA"; exit 1; }
+              sleep 10
+            done
+          done
+
+          # Smoke test: the deep DB-backed readiness endpoint (C.6).
+          curl -fsSL https://api.hearthly.dev/health/deep | grep -q '"status":"ok"'

--- a/infrastructure/cluster-services/argocd/values.yaml
+++ b/infrastructure/cluster-services/argocd/values.yaml
@@ -14,6 +14,19 @@ global:
 configs:
   params:
     server.insecure: true
+  # Read-only API account for the deploy workflow's ArgoCD revision check (D.4).
+  # apiKey only (no UI login). Generate its token once after this syncs:
+  #   argocd account generate-token --account deploy-verify
+  # then store it as the GitHub repo secret ARGOCD_TOKEN.
+  cm:
+    accounts.deploy-verify: apiKey
+  # Least-privilege: deploy-verify may only `get` applications (the verify job
+  # reads status.sync.revision/health). admin keeps full access via the built-in
+  # role; policy.default stays empty (no blanket grant).
+  rbac:
+    policy.csv: |
+      p, role:deploy-verify, applications, get, */*, allow
+      g, deploy-verify, role:deploy-verify
 
 # Disable components we don't need yet
 dex:


### PR DESCRIPTION
## What

Task **D.4** — make the deploy workflow prove the cluster actually ran the code it just built, instead of assuming the push = a live deploy.

- `update-tags` now outputs `commit_sha` (the tag-bump commit it pushed; empty if nothing changed).
- New **`verify`** job: for each changed+built app, polls the ArgoCD API until `status.sync.revision == <pushed SHA>` **and** `Synced/Healthy`, then smoke-tests `https://api.hearthly.dev/health/deep` (C.6).
- New least-privilege ArgoCD account **`deploy-verify`** (`apiKey`, `get` on applications only) in `argocd/values.yaml`.

## Why

Per Codex finding #8 + follow-up: checking only `Synced/Healthy` can pass against the **previous** revision (ArgoCD was already green before this deploy). The verify must assert the deployed revision **equals the commit we just pushed** — otherwise a stuck/slow sync looks green.

## Safe to merge now

The verify job **no-ops with a warning** until the `ARGOCD_TOKEN` secret exists (same graceful-skip pattern as the deadman check in `healthcheck.yml`). Nothing breaks before the token is set.

### Follow-up to activate (one-time, needs ArgoCD admin + repo admin)

After this merges and ArgoCD syncs the new `deploy-verify` account:
```bash
argocd login argocd.hearthly.dev              # as admin
argocd account generate-token --account deploy-verify
gh secret set ARGOCD_TOKEN                     # paste the token (rudingma/admin)
```
`ARGOCD_TOKEN` is a pure-CI credential → GitHub-only, never added to Infisical (per BOOTSTRAP.md).

## Verification

- `helm template` → `argocd-cm` gets `accounts.deploy-verify: apiKey`; `argocd-rbac-cm` gets the read-only policy; `policy.default` stays empty (no blanket grant); admin unaffected.
- `deploy.yml` parses; `verify` job wired to `update-tags.outputs.commit_sha`.
- `prettier --check` clean.

### Known limitation

The revision check is an **exact** match (`rev == WANT_SHA`). If a newer commit lands on main before ArgoCD syncs this one, the job could time out — acceptable for the normal serialized-deploy case (update-tags rebases onto HEAD); noted in a code comment.

Part of #131.