### PR TITLE
infra(terraform): enforce state locking via native S3 use_lockfile (C.5) (#126)

### DIFF
--- a/infrastructure/CLAUDE.md
+++ b/infrastructure/CLAUDE.md
@@ -100,7 +100,7 @@ Default-deny both ingress and egress per namespace. 35 policies across 6 namespa
 - **Deploy:** `deploy.yml` — builds API, App, Keycloak on ARM64 runners, Trivy scan before push
 - **Terraform:** `terraform.yml` — plan on PR (posted as comment), apply on merge. CI reads bootstrap secrets from **GitHub Encrypted Secrets** (NOT Infisical) — see `cluster/BOOTSTRAP.md`. Infisical runs inside the cluster Terraform repairs, so fetching bootstrap creds from it was a proven circular dependency during the 2026-05 outage (#131, Task C.4). The duplicated secrets (`S3_*`, `KEYCLOAK_ADMIN_PASSWORD`) stay in Infisical for in-cluster consumers; rotate in Infisical **and** re-set the GitHub Secret.
 - **ARM64 runners require public repo** — if repo goes private, Docker build jobs fail
-- **Terraform concurrency:** serialized per module (`cancel-in-progress: false`) — Hetzner S3 has no state locking. **No manual `terraform apply` while CI is running.**
+- **Terraform concurrency:** serialized per module (`cancel-in-progress: false`). **State locking is enforced** via the S3 backend's native `use_lockfile` (Task C.5 / #126) — a concurrent apply (CI _or_ manual) fails fast on the `<key>.tflock` object instead of corrupting state, so the old "no manual apply during CI" rule is now machine-enforced rather than convention. If a run dies holding the lock, clear it with `terraform force-unlock <lock-id>`. (Hetzner Ceph caveat: if a lock write returns `XAmzContentSHA256Mismatch`, the backend blocks carry a `skip_s3_checksum` fallback note.)
 
 ## Terraform Commands
 

--- a/infrastructure/cluster/main.tf
+++ b/infrastructure/cluster/main.tf
@@ -1,5 +1,6 @@
 terraform {
-  required_version = ">= 1.5.0"
+  # use_lockfile (native S3 state locking) requires Terraform >= 1.10.
+  required_version = ">= 1.10.0"
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
@@ -24,6 +25,15 @@ terraform {
     skip_region_validation      = true
     skip_requesting_account_id  = true
     use_path_style              = true
+
+    # Native S3 state locking (Task C.5 / #126): writes a <key>.tflock object
+    # via S3 conditional writes — no DynamoDB, state stays in Hetzner. Enforces
+    # locking for BOTH CI and manual applies, replacing the convention-only
+    # mitigation. NOTE: if Hetzner's Ceph S3 rejects the lock write with
+    # `XAmzContentSHA256Mismatch`, add `skip_s3_checksum = true` here (the
+    # documented Ceph workaround). Verified by this module's `terraform plan`
+    # on PR — a plan only acquires+releases the lock; it never mutates state.
+    use_lockfile = true
   }
 }
 

--- a/infrastructure/keycloak-config/main.tf
+++ b/infrastructure/keycloak-config/main.tf
@@ -1,5 +1,6 @@
 terraform {
-  required_version = ">= 1.5.0"
+  # use_lockfile (native S3 state locking) requires Terraform >= 1.10.
+  required_version = ">= 1.10.0"
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
@@ -24,6 +25,11 @@ terraform {
     skip_region_validation      = true
     skip_requesting_account_id  = true
     use_path_style              = true
+
+    # Native S3 state locking (Task C.5 / #126) — see the cluster module's
+    # backend block for the full rationale + the Hetzner-Ceph `skip_s3_checksum`
+    # fallback if the lock write returns `XAmzContentSHA256Mismatch`.
+    use_lockfile = true
   }
 }
 


### PR DESCRIPTION
## What

Task **C.5** / closes **#126**. Adds `use_lockfile = true` to both Terraform `backend "s3"` blocks (`cluster` + `keycloak-config`) and bumps `required_version` to `>= 1.10.0` (when `use_lockfile` was introduced).

## Why this option

#126 predates Terraform's native S3 locking. Since TF 1.10 the S3 backend locks via a `<key>.tflock` object using S3 **conditional writes** — **no DynamoDB, state stays in Hetzner, pure config**. It enforces locking for **both CI and manual applies**, so the old "no manual apply during CI" convention is now machine-enforced. This beats the three options listed in #126 (AWS S3+DynamoDB = cross-cloud + new vendor; TF Cloud = new vendor; CI shim = more code, still bypassable).

## Verification gate — the Terraform plan jobs on this PR

This PR changes `*.tf` in both modules, so the **`Terraform` workflow's `plan-cluster` + `plan-keycloak-config` jobs run** with `use_lockfile` enabled, against Hetzner, using the CI secrets. **A `terraform plan` only acquires + releases the lock — it never mutates state**, so this is a safe end-to-end verification.

**Do not merge until both plan jobs succeed.**

- ✅ plan jobs succeed → locking works on Hetzner; merge (apply-on-merge also locks).
- ❌ plan fails with `XAmzContentSHA256Mismatch` → Hetzner's Ceph needs the checksum workaround; I'll push `skip_s3_checksum = true` (already noted in the backend comment) and re-run.

## Local checks

- `terraform fmt -check` clean on both files.
- `prettier --check` clean (CLAUDE.md updated; `.tf` not in Prettier scope).
- Docs: `infrastructure/CLAUDE.md` "Terraform concurrency" note updated to reflect enforced locking + `force-unlock` recovery.

Closes #126. Part of #131.